### PR TITLE
perf(core): Implement LRU In-Memory Cache for Composite Feed Ranking Engine (fixes #9)

### DIFF
--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -9,8 +9,42 @@ import { getFilteredFallbacks } from './staticFallbacks';
 
 const API_BASE_URL = "/api/v1";
 
-// Simple persistent cache for fallbacks
+class LRUCache<K, V> {
+  private capacity: number;
+  private cache: Map<K, { value: V; timestamp: number }>;
+
+  constructor(capacity: number) {
+    this.capacity = capacity;
+    this.cache = new Map();
+  }
+
+  get(key: K): V | undefined {
+    if (!this.cache.has(key)) return undefined;
+    
+    const item = this.cache.get(key)!;
+    // Refresh the item's position
+    this.cache.delete(key);
+    this.cache.set(key, item);
+    return item.value;
+  }
+
+  set(key: K, value: V) {
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    } else if (this.cache.size >= this.capacity) {
+      // Remove the first (least recently used) item
+      const firstKey = this.cache.keys().next().value;
+      if (firstKey) this.cache.delete(firstKey);
+    }
+    this.cache.set(key, { value, timestamp: Date.now() });
+  }
+}
+
+const memoryCache = new LRUCache<string, any>(50); // Store up to 50 feeds/queries
+
+// Two-tier cache: LRU in-memory + persistent localStorage fallback
 const saveToCache = (key: string, data: any) => {
+  memoryCache.set(key, data);
   try {
     localStorage.setItem(`cache_${key}`, JSON.stringify({
       data,
@@ -22,9 +56,16 @@ const saveToCache = (key: string, data: any) => {
 };
 
 const getFromCache = (key: string) => {
+  const mem = memoryCache.get(key);
+  if (mem) return mem;
+
   try {
     const cached = localStorage.getItem(`cache_${key}`);
-    if (cached) return JSON.parse(cached).data;
+    if (cached) {
+      const parsed = JSON.parse(cached).data;
+      memoryCache.set(key, parsed);
+      return parsed;
+    }
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
## Description

This PR implements a robust L1 LRU in-memory cache directly into the `apiClient` to dramatically speed up feed rendering and query retrieval. By maintaining the 50 most recently accessed queries/feeds in memory (L1) and utilizing `localStorage` as a persistent L2 fallback, we eliminate redundant disk I/O and JSON parsing for frequent navigations.

## Related Issue

Closes #9

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Performance optimization

## Checklist

- [x] I have self-reviewed my code.
- [x] I have tested these changes locally.
- [x] There are no new console errors or warnings.
- [x] My code follows the existing code style.

## Additional Notes

- Replaced basic persistent cache with a generic `LRUCache<K, V>` class.
- The `get` function refreshes access times (LRU eviction).
- Protects memory footprint automatically (capacity bounded).
