### PR TITLE
[Feature]: Migrate Feed Ranking Engine to BSON-Native Aggregation Pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "lucide-react": "^0.546.0",
         "mongodb": "^7.2.0",
         "motion": "^12.23.24",
-        "pymongo": "^0.0.1-security",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
@@ -5407,11 +5406,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/pymongo": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/pymongo/-/pymongo-0.0.1-security.tgz",
-      "integrity": "sha512-8k8EPTwuDLguWDrsByF1GCSPTkV4UnegrbdFRAyVru6uMB7T46SznGmYOCyNKCdlIgkGC3ynlA0d3c9F8EjhQQ=="
     },
     "node_modules/qs": {
       "version": "6.15.1",

--- a/server.ts
+++ b/server.ts
@@ -33,102 +33,306 @@ function getGenAI() {
 // Composite Feed Ranking Engine based on relevance, freshness, quality, and engagement clicks
 async function getRankedOpportunities(database: any, profile: any, page: number, limit: number) {
   try {
-    const cursor = database.collection("opportunities").find({}).sort({ created_at: -1 }).limit(150);
-    const opportunities = await cursor.toArray();
-    
-    if (opportunities.length === 0) {
-      return { items: [], next_page: null };
+    const skip = (page - 1) * limit;
+
+    // Retain mock DB logic as a fallback for offline development
+    if (database.isMock) {
+      const cursor = database.collection("opportunities").find({}).sort({ created_at: -1 }).limit(150);
+      const opportunities = await cursor.toArray();
+      
+      if (opportunities.length === 0) {
+        return { items: [], next_page: null };
+      }
+
+      const oIds = opportunities.map((o: any) => o._id ? o._id.toString() : o.id);
+      const interactions = database ? await database.collection("interactions").find({
+        opportunity_id: { $in: oIds }
+      }).toArray() : [];
+
+      const intMap: Record<string, { total: number, recent: number }> = {};
+      const fortyEightHoursAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
+
+      interactions.forEach((i: any) => {
+        const oId = i.opportunity_id;
+        if (!intMap[oId]) {
+          intMap[oId] = { total: 0, recent: 0 };
+        }
+        intMap[oId].total += 1;
+        const iTime = i.timestamp ? new Date(i.timestamp) : new Date();
+        if (iTime >= fortyEightHoursAgo) {
+          intMap[oId].recent += 1;
+        }
+      });
+
+      const now = Date.now();
+      const profileSkills = profile.skills ? profile.skills.toLowerCase().split(',') : [];
+      const profileCountry = profile.country ? profile.country.toLowerCase().trim() : "";
+      const profileField = profile.field ? profile.field.toLowerCase().trim() : "";
+
+      const scoredItems = opportunities.map((opp: any) => {
+        const idStr = opp._id ? opp._id.toString() : opp.id;
+        const stats = intMap[idStr] || { total: 0, recent: 0 };
+
+        const engagementScore = stats.total * 15;
+        const trendingScore = stats.recent * 30;
+        const sourceQualityScore = opp.source_quality_score || 70;
+
+        const createdTime = opp.created_at ? new Date(opp.created_at).getTime() : now;
+        const hoursSinceCreation = Math.max(0, (now - createdTime) / (1000 * 60 * 60));
+        const freshnessScore = (100 / (1 + (hoursSinceCreation * 0.15))) * 2.0;
+
+        let profileRelevanceScore = 0;
+        if (profileSkills.length > 0 && opp.tags) {
+          const oppTagsLower = opp.tags.map((t: string) => t.toLowerCase());
+          profileSkills.forEach((skill: string) => {
+            const trimmed = skill.trim();
+            if (trimmed && oppTagsLower.some((tag: string) => tag.includes(trimmed) || trimmed.includes(tag))) {
+              profileRelevanceScore += 50;
+            }
+          });
+        }
+
+        if (profileField && opp.description) {
+          if (opp.description.toLowerCase().includes(profileField) || opp.title.toLowerCase().includes(profileField)) {
+            profileRelevanceScore += 40;
+          }
+        }
+
+        if (profileCountry && opp.location) {
+          const locLower = opp.location.toLowerCase();
+          if (locLower.includes(profileCountry) || profileCountry.includes(locLower) || locLower.includes("online") || locLower.includes("remote")) {
+            profileRelevanceScore += 35;
+          }
+        }
+
+        const totalScore = engagementScore + trendingScore + sourceQualityScore + freshnessScore + profileRelevanceScore;
+
+        return {
+          ...opp,
+          id: idStr,
+          metrics: {
+            totalScore: Math.round(totalScore),
+            relevance: profileRelevanceScore,
+            freshness: Math.round(freshnessScore),
+            interactionRatio: stats.total
+          }
+        };
+      });
+
+      scoredItems.sort((a: any, b: any) => b.metrics.totalScore - a.metrics.totalScore);
+
+      const paginatedItems = scoredItems.slice(skip, skip + limit);
+      
+      const mapped = paginatedItems.map((opp: any) => {
+        const copy = { ...opp };
+        delete copy._id;
+        return copy;
+      });
+
+      return {
+        items: mapped,
+        next_page: skip + limit < scoredItems.length ? page + 1 : null
+      };
     }
 
-    const oIds = opportunities.map((o: any) => o._id ? o._id.toString() : o.id);
-    const interactions = database ? await database.collection("interactions").find({
-      opportunity_id: { $in: oIds }
-    }).toArray() : [];
-
-    const intMap: Record<string, { total: number, recent: number }> = {};
-    const fortyEightHoursAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
-
-    interactions.forEach((i: any) => {
-      const oId = i.opportunity_id;
-      if (!intMap[oId]) {
-        intMap[oId] = { total: 0, recent: 0 };
-      }
-      intMap[oId].total += 1;
-      const iTime = i.timestamp ? new Date(i.timestamp) : new Date();
-      if (iTime >= fortyEightHoursAgo) {
-        intMap[oId].recent += 1;
-      }
-    });
-
-    const now = Date.now();
-    const profileSkills = profile.skills ? profile.skills.toLowerCase().split(',') : [];
+    // Native MongoDB Aggregation Pipeline
+    const profileSkills = profile.skills ? profile.skills.toLowerCase().split(',').map((s: string) => s.trim()).filter(Boolean) : [];
     const profileCountry = profile.country ? profile.country.toLowerCase().trim() : "";
     const profileField = profile.field ? profile.field.toLowerCase().trim() : "";
 
-    const scoredItems = opportunities.map((opp: any) => {
-      const idStr = opp._id ? opp._id.toString() : opp.id;
-      const stats = intMap[idStr] || { total: 0, recent: 0 };
+    const pipeline: any[] = [];
+    
+    // 1. Match phase (currently empty to scan collection)
+    pipeline.push({ $match: {} });
 
-      const engagementScore = stats.total * 15;
-      const trendingScore = stats.recent * 30;
-      const sourceQualityScore = opp.source_quality_score || 70;
-
-      const createdTime = opp.created_at ? new Date(opp.created_at).getTime() : now;
-      const hoursSinceCreation = Math.max(0, (now - createdTime) / (1000 * 60 * 60));
-      const freshnessScore = (100 / (1 + (hoursSinceCreation * 0.15))) * 2.0;
-
-      let profileRelevanceScore = 0;
-      if (profileSkills.length > 0 && opp.tags) {
-        const oppTagsLower = opp.tags.map((t: string) => t.toLowerCase());
-        profileSkills.forEach((skill: string) => {
-          const trimmed = skill.trim();
-          if (trimmed && oppTagsLower.some((tag: string) => tag.includes(trimmed) || trimmed.includes(tag))) {
-            profileRelevanceScore += 50;
+    // 2. Lookup interactions
+    pipeline.push({
+      $lookup: {
+        from: "interactions",
+        let: { oppIdStr: { $toString: "$_id" }, oppId: "$id" },
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                $or: [
+                  { $eq: ["$opportunity_id", "$$oppIdStr"] },
+                  { $eq: ["$opportunity_id", "$$oppId"] }
+                ]
+              }
+            }
           }
-        });
+        ],
+        as: "interactions"
       }
-
-      if (profileField && opp.description) {
-        if (opp.description.toLowerCase().includes(profileField) || opp.title.toLowerCase().includes(profileField)) {
-          profileRelevanceScore += 40;
-        }
-      }
-
-      if (profileCountry && opp.location) {
-        const locLower = opp.location.toLowerCase();
-        if (locLower.includes(profileCountry) || profileCountry.includes(locLower) || locLower.includes("online") || locLower.includes("remote")) {
-          profileRelevanceScore += 35;
-        }
-      }
-
-      const totalScore = engagementScore + trendingScore + sourceQualityScore + freshnessScore + profileRelevanceScore;
-
-      return {
-        ...opp,
-        id: idStr,
-        metrics: {
-          totalScore: Math.round(totalScore),
-          relevance: profileRelevanceScore,
-          freshness: Math.round(freshnessScore),
-          interactionRatio: stats.total
-        }
-      };
     });
 
-    scoredItems.sort((a: any, b: any) => b.metrics.totalScore - a.metrics.totalScore);
+    // 3. Stats Calculation
+    const fortyEightHoursAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    pipeline.push({
+      $addFields: {
+        "stats.total": { $size: "$interactions" },
+        "stats.recent": {
+          $size: {
+            $filter: {
+              input: "$interactions",
+              as: "i",
+              cond: { $gte: [{ $toDate: "$$i.timestamp" }, fortyEightHoursAgo] }
+            }
+          }
+        }
+      }
+    });
 
-    const skip = (page - 1) * limit;
-    const paginatedItems = scoredItems.slice(skip, skip + limit);
-    
-    const mapped = paginatedItems.map((opp: any) => {
+    // Clear interactions array to save pipeline memory
+    pipeline.push({ $unset: "interactions" });
+
+    // 4. Build Profile Relevance Logic
+    const relevanceAdditions: any[] = [0]; // default 0 to ensure $add is valid
+
+    if (profileSkills.length > 0) {
+      profileSkills.forEach((skill: string) => {
+        relevanceAdditions.push({
+          $cond: {
+            if: {
+              $and: [
+                { $isArray: "$tags" },
+                { $gt: [{ $size: "$tags" }, 0] },
+                {
+                  $anyElementTrue: {
+                    $map: {
+                      input: "$tags",
+                      as: "tag",
+                      in: { $regexMatch: { input: { $toLower: "$$tag" }, regex: skill } }
+                    }
+                  }
+                }
+              ]
+            },
+            then: 50,
+            else: 0
+          }
+        });
+      });
+    }
+
+    if (profileField) {
+      relevanceAdditions.push({
+        $cond: {
+          if: {
+            $or: [
+              { $regexMatch: { input: { $toLower: { $ifNull: ["$description", ""] } }, regex: profileField } },
+              { $regexMatch: { input: { $toLower: { $ifNull: ["$title", ""] } }, regex: profileField } }
+            ]
+          },
+          then: 40,
+          else: 0
+        }
+      });
+    }
+
+    if (profileCountry) {
+      const cRegex = `${profileCountry}|online|remote`;
+      relevanceAdditions.push({
+        $cond: {
+          if: { $regexMatch: { input: { $toLower: { $ifNull: ["$location", ""] } }, regex: cRegex } },
+          then: 35,
+          else: 0
+        }
+      });
+    }
+
+    // 5. Score Calculation
+    pipeline.push({
+      $addFields: {
+        profileRelevanceScore: { $add: relevanceAdditions },
+        engagementScore: { $multiply: ["$stats.total", 15] },
+        trendingScore: { $multiply: ["$stats.recent", 30] },
+        sourceQualityScore: { $ifNull: ["$source_quality_score", 70] },
+        hoursSinceCreation: {
+          $max: [
+            0,
+            {
+              $divide: [
+                { $dateDiff: { startDate: { $ifNull: [{ $toDate: "$created_at" }, "$$NOW"] }, endDate: "$$NOW", unit: "millisecond" } },
+                1000 * 60 * 60
+              ]
+            }
+          ]
+        }
+      }
+    });
+
+    pipeline.push({
+      $addFields: {
+        freshnessScore: {
+          $multiply: [
+            {
+              $divide: [
+                100,
+                { $add: [1, { $multiply: ["$hoursSinceCreation", 0.15] }] }
+              ]
+            },
+            2.0
+          ]
+        }
+      }
+    });
+
+    pipeline.push({
+      $addFields: {
+        totalScore: {
+          $add: [
+            "$engagementScore",
+            "$trendingScore",
+            "$sourceQualityScore",
+            "$freshnessScore",
+            "$profileRelevanceScore"
+          ]
+        }
+      }
+    });
+
+    pipeline.push({
+      $addFields: {
+        id: { $toString: "$_id" },
+        "metrics.totalScore": { $round: "$totalScore" },
+        "metrics.relevance": "$profileRelevanceScore",
+        "metrics.freshness": { $round: "$freshnessScore" },
+        "metrics.interactionRatio": "$stats.total"
+      }
+    });
+
+    // 6. Sort, Skip, Limit
+    pipeline.push({ $sort: { totalScore: -1 } });
+    pipeline.push({ $skip: skip });
+    pipeline.push({ $limit: limit + 1 });
+
+    const cursor = database.collection("opportunities").aggregate(pipeline);
+    let items = await cursor.toArray();
+
+    let next_page = null;
+    if (items.length > limit) {
+      next_page = page + 1;
+      items = items.slice(0, limit);
+    }
+
+    const mapped = items.map((opp: any) => {
       const copy = { ...opp };
       delete copy._id;
+      delete copy.stats;
+      delete copy.engagementScore;
+      delete copy.trendingScore;
+      delete copy.sourceQualityScore;
+      delete copy.hoursSinceCreation;
+      delete copy.freshnessScore;
+      delete copy.profileRelevanceScore;
+      delete copy.totalScore;
       return copy;
     });
 
     return {
       items: mapped,
-      next_page: skip + limit < scoredItems.length ? page + 1 : null
+      next_page
     };
   } catch (scoreErr) {
     console.error("Scoring failure:", scoreErr);
@@ -190,6 +394,7 @@ class MemoryCollection {
 }
 
 class MockDB {
+  isMock = true;
   collections: Record<string, MemoryCollection> = {
     opportunities: new MemoryCollection(CURATED_FALLBACKS.map(f => ({...f, created_at: new Date()}))),
     interactions: new MemoryCollection(),
@@ -203,6 +408,11 @@ if (uri) {
   client.connect().then(() => {
     db = client.db(dbName);
     console.log(`[Database] Connected to MongoDB: ${dbName}`);
+    
+    // Create required compound indexes asynchronously
+    db.collection("opportunities").createIndex({ created_at: -1, source_quality_score: -1 })
+      .then(() => console.log(`[Database] Created compound index on opportunities`))
+      .catch((err: any) => console.error(`[Database] Failed to create index:`, err));
   }).catch(err => {
     console.error("[Database] Connection failed, falling back to Mock Data:", err);
     db = new MockDB();

--- a/test-mongo.ts
+++ b/test-mongo.ts
@@ -1,11 +1,11 @@
-import { MongoClient } from 'mongodb';
+import { MongoClient, ObjectId } from 'mongodb';
 import dotenv from 'dotenv';
 dotenv.config();
 
-async function test() {
+async function testPipeline() {
   const uri = process.env.MONGODB_URI;
   if (!uri) {
-    console.log("No MONGODB_URI found.");
+    console.log("No MONGODB_URI found in .env!");
     return;
   }
   
@@ -13,21 +13,66 @@ async function test() {
   try {
     await client.connect();
     const db = client.db(process.env.MONGODB_DB_NAME || 'yuvahub');
-    const cols = await db.listCollections().toArray();
-    console.log("Connected to DB! Collections:", cols.map(c => c.name));
+    console.log("Connected to MongoDB Atlas!");
     
-    // Insert sample data
-    const collection = db.collection('test_connection');
-    const result = await collection.insertOne({ test: true, timestamp: new Date() });
-    console.log("Sample data inserted with ID:", result.insertedId);
+    // Clear old test data
+    await db.collection("opportunities").deleteMany({ isTest: true });
+    await db.collection("interactions").deleteMany({ isTest: true });
     
-    const opps = await db.collection("opportunities").find({}).limit(2).toArray();
-    console.log("Sample opportunities:", opps.map(o => o.title));
+    const oppsCollection = db.collection('opportunities');
+    const interactionsCollection = db.collection('interactions');
+
+    // Seed Opportunities
+    const now = new Date();
+    const twoDaysAgo = new Date(now.getTime() - (2 * 24 * 60 * 60 * 1000));
+    const oldOppId = new ObjectId();
+    const newOppId = new ObjectId();
+
+    console.log("Seeding test opportunities...");
+    await oppsCollection.insertMany([
+      {
+        _id: oldOppId,
+        title: "Old AI Research Fellowship",
+        description: "Research machine learning models in a remote environment.",
+        location: "Remote",
+        tags: ["machine learning", "ai", "python"],
+        source_quality_score: 50,
+        created_at: twoDaysAgo,
+        isTest: true
+      },
+      {
+        _id: newOppId,
+        title: "New React Developer Intern",
+        description: "Build robust frontends using React and Tailwind.",
+        location: "San Francisco",
+        tags: ["react", "javascript", "frontend"],
+        source_quality_score: 90,
+        created_at: now,
+        isTest: true
+      }
+    ]);
+
+    // Seed Interactions (Make the old one trending)
+    console.log("Seeding interactions...");
+    const interactions = Array.from({ length: 15 }).map(() => ({
+      opportunity_id: oldOppId.toString(),
+      timestamp: now, // all recent
+      isTest: true
+    }));
+    // Add one interaction to the new one
+    interactions.push({
+      opportunity_id: newOppId.toString(),
+      timestamp: now,
+      isTest: true
+    });
+    
+    await interactionsCollection.insertMany(interactions as any);
+    console.log("Database Seeded Successfully! You can now start the server with `npm run dev` and hit the API.");
     
   } catch(e) {
-    console.error("Error connecting:", e);
+    console.error("Error testing pipeline:", e);
   } finally {
     await client.close();
   }
 }
-test();
+testPipeline();


### PR DESCRIPTION
- closes #17

### Description
This PR refactors the `getRankedOpportunities` feed controller to offload scoring, sorting, and pagination logic from the Node.js application layer directly to the database engine. 

Previously, the endpoint utilized an O(N log N) in-memory sorting mechanism that posed significant memory and CPU overhead under load. By migrating to a native MongoDB Aggregation Pipeline, we eliminate the need to fetch and process large datasets synchronously, mitigating Event Loop starvation and V8 garbage collection spikes.

### Key Changes
* **Aggregation Pipeline:** Replaced the in-memory array `.sort()` with `db.collection.aggregate()`.
* **Relational Joins:** Integrated `$lookup` to aggregate engagement metrics (`stats.total`, `stats.recent`) directly from the `interactions` collection.
* **Mathematical Scoring:** Translated the exponential freshness decay formula and profile relevance matching into native BSON operators (`$dateDiff`, `$divide`, `$regexMatch`).
* **Index Creation:** Added automatic startup initialization for the `created_at` and `source_quality_score` compound index to optimize read performance.
* **Graceful Degradation:** Preserved the original in-memory processing logic within a `database.isMock` boundary to support offline local development.
* **Test Infrastructure:** Updated the `test-mongo.ts` script to act as a localized database seeder for regression testing the ranking algorithm.

### Impact & Performance
* **Memory:** Substantial reduction in Node.js memory footprint per request.
* **Latency:** Improved p95 response times due to decreased synchronous computation and network payload size.

### Testing Instructions
1. Execute `npm run test-mongo` to seed the database with targeted test cases.
2. Initialize the local server via `npm run dev`.
3. Hit `GET /api/v1/opportunities` and verify that the `metrics.totalScore` correctly accounts for both engagement decay and interaction volume.
