### PR TITLE
fix: remove duplicate vite from dependencies (#12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "socket.io-client": "^4.8.3",
         "tailwind-merge": "^3.5.0",
         "tsx": "^4.21.0",
-        "vite": "^6.2.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "socket.io-client": "^4.8.3",
     "tailwind-merge": "^3.5.0",
     "tsx": "^4.21.0",
-    "vite": "^6.2.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description
This PR resolves issue #12 by removing the duplicate `vite` entry from the `dependencies` block in `package.json`. `vite` is a build tool and should strictly live under `devDependencies`.

### Changes Made
- Removed `"vite"` from `dependencies` in `package.json`.
- Kept `"vite"` under `devDependencies`.
- Updated `package-lock.json` by running `npm install` to reflect the dependency tree cleanup.

### Closes
Closes #12