### PR TITLE
feat: add dark/light theme toggle with local storage persistence (#1)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { LayoutDashboard, Globe, PlusCircle, Users, User, Menu, X, Activity, Bookmark, Sparkles, MessageSquare, Settings } from 'lucide-react';
+import { LayoutDashboard, Globe, PlusCircle, Users, User, Menu, X, Activity, Bookmark, Sparkles, MessageSquare, Settings, Sun, Moon } from 'lucide-react';
 import { signInWithGoogle, logout } from './lib/firebase';
 import { UserProfile } from './types';
 import { useAppContext } from './context/AppContext';
@@ -35,7 +35,9 @@ function App() {
     appSearchQuery,
     setAppSearchQuery,
     selectedOppId,
-    clearSelectedOpportunity
+    clearSelectedOpportunity,
+    theme,
+    toggleTheme
   } = useAppContext();
 
   // WebMCP Integration
@@ -136,15 +138,15 @@ function App() {
   }
 
   return (
-    <div className="flex h-screen bg-gray-50 text-gray-900 font-sans overflow-hidden">
+    <div className="flex h-screen bg-gray-50 text-gray-900 font-sans overflow-hidden dark:bg-gray-900 dark:text-gray-100">
       
       {/* Sidebar Desktop - Fixed 220px */}
-      <aside className="hidden lg:flex w-55 border-r border-[#E2E8F0] flex-col bg-white z-10 shrink-0 relative">
+      <aside className="hidden lg:flex w-55 border-r border-[#E2E8F0] dark:border-gray-700 flex-col bg-white dark:bg-gray-800 z-10 shrink-0 relative">
         <div className="p-6 border-b border-[#E2E8F0] flex items-center justify-center gap-2">
           <div className="w-7 h-7 rounded-lg bg-[#2563EB] flex items-center justify-center">
              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-white"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
           </div>
-          <h1 className="text-lg font-bold tracking-tight text-gray-900">
+          <h1 className="text-lg font-bold tracking-tight text-gray-900 dark:text-white">
             YuvaHub
           </h1>
         </div>
@@ -159,7 +161,7 @@ function App() {
                   setActiveTab(tab.id);
                   clearSelectedOpportunity();
                 }}
-                className={`w-full flex items-center gap-3 px-4 py-3 text-sm font-medium transition-all rounded-lg ${isActive ? 'bg-blue-50 text-blue-700 border-l-4 border-blue-600' : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900 border-l-4 border-transparent'}`}
+                className={`w-full flex items-center gap-3 px-4 py-3 text-sm font-medium transition-all rounded-lg ${isActive ? 'bg-blue-50 dark:bg-blue-950/50 text-blue-700 dark:text-blue-400 border-l-4 border-blue-600' : 'text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white border-l-4 border-transparent'}`}
                 style={{ borderLeftWidth: isActive ? '4px' : '0px', paddingLeft: isActive ? '12px' : '16px' }}
               >
                 <Icon className={`w-5 h-5 ${isActive ? 'text-blue-600' : 'text-gray-400'}`} />
@@ -168,10 +170,19 @@ function App() {
             )
           })}
         </nav>
-        <div className="p-4 border-t border-gray-100">
+        <div className="px-4 pt-4">
+          <button
+            onClick={toggleTheme}
+            className="w-full flex items-center gap-3 px-4 py-3 text-sm font-medium rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-all"
+          >
+            {theme === 'dark' ? <Sun className="w-5 h-5 text-gray-400" /> : <Moon className="w-5 h-5 text-gray-400" />}
+            {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+          </button>
+        </div>
+        <div className="p-4 border-t border-gray-100 dark:border-gray-700">
           {user ? (
             <div className="flex flex-col gap-3">
-              <span className="text-xs text-gray-500 font-medium truncate px-2">{user.email}</span>
+              <span className="text-xs text-gray-500 dark:text-gray-400 font-medium truncate px-2">{user.email}</span>
               <button onClick={logout} className="clean-btn-outline w-full py-2 text-sm">Logout</button>
             </div>
           ) : (
@@ -183,18 +194,18 @@ function App() {
       </aside>
 
       {/* Mobile Header */}
-      <div className="lg:hidden fixed top-0 left-0 right-0 h-16 border-b border-gray-200 bg-white z-50 flex items-center justify-between px-4">
+      <div className="lg:hidden fixed top-0 left-0 right-0 h-16 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 z-50 flex items-center justify-between px-4">
         <div className="flex items-center gap-2">
           <div className="w-8 h-8 rounded-lg bg-[#2563EB] flex items-center justify-center">
              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-white"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
           </div>
-          <h1 className="text-lg font-bold tracking-tight text-gray-900">
+          <h1 className="text-lg font-bold tracking-tight text-gray-900 dark:text-white">
             YuvaHub
           </h1>
         </div>
         <div className="flex items-center gap-4">
           <NotificationDropdown profile={profile} />
-          <button onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)} className="text-gray-500 hover:text-gray-900">
+          <button onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)} className="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white">
             {isMobileMenuOpen ? <X /> : <Menu />}
           </button>
         </div>
@@ -202,7 +213,7 @@ function App() {
 
       {/* Mobile Menu */}
       {isMobileMenuOpen && (
-        <div className="lg:hidden fixed inset-0 top-16 bg-white z-40 p-4 border-b border-gray-200 overflow-y-auto">
+        <div className="lg:hidden fixed inset-0 top-16 bg-white dark:bg-gray-900 z-40 p-4 border-b border-gray-200 dark:border-gray-700 overflow-y-auto">
           <nav className="space-y-2">
             {TABS.map(tab => {
               const Icon = tab.icon;
@@ -215,14 +226,21 @@ function App() {
                     clearSelectedOpportunity();
                     setIsMobileMenuOpen(false);
                   }}
-                  className={`w-full flex items-center gap-3 px-4 py-4 text-sm font-medium transition-all rounded-lg ${isActive ? 'bg-blue-50 text-blue-700 border-l-4 border-blue-600' : 'text-gray-600 hover:bg-gray-50 border-l-4 border-transparent'}`}
+                  className={`w-full flex items-center gap-3 px-4 py-4 text-sm font-medium transition-all rounded-lg ${isActive ? 'bg-blue-50 dark:bg-blue-950/50 text-blue-700 dark:text-blue-400 border-l-4 border-blue-600' : 'text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 border-l-4 border-transparent'}`}
                 >
                   <Icon className="w-5 h-5" />
                   {tab.label}
                 </button>
               )
             })}
-            <div className="pt-6 mt-6 border-t border-gray-100">
+            <button
+              onClick={toggleTheme}
+              className="w-full flex items-center gap-3 px-4 py-4 text-sm font-medium rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-all"
+            >
+              {theme === 'dark' ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+              {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+            </button>
+            <div className="pt-6 mt-6 border-t border-gray-100 dark:border-gray-700">
               {user ? (
                 <button onClick={() => { logout(); setIsMobileMenuOpen(false); }} className="clean-btn-outline w-full py-3 text-sm">Logout</button>
               ) : (
@@ -238,17 +256,17 @@ function App() {
       <main className="flex-1 flex flex-col pt-16 lg:pt-0 h-screen overflow-hidden relative">
         
         {/* Topbar */}
-        <div className="hidden lg:flex h-[60px] border-b border-[#E2E8F0] bg-white items-center justify-between px-6 shrink-0">
+        <div className="hidden lg:flex h-[60px] border-b border-[#E2E8F0] dark:border-gray-700 bg-white dark:bg-gray-800 items-center justify-between px-6 shrink-0">
            <div className="flex-1 max-w-[500px] ml-8 mr-8">
               {activeTab === 'opportunities' ? (
                  <div className="relative">
                     <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
                     </div>
-                    <input type="text" placeholder="Search standard competitions..." className="w-full bg-[#F8FAFC] border border-gray-200 outline-none rounded-lg pl-10 pr-4 py-2 text-sm focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all" value={appSearchQuery} onChange={(e) => setAppSearchQuery(e.target.value)} />
+                    <input type="text" placeholder="Search standard competitions..." className="w-full bg-[#F8FAFC] dark:bg-gray-700 border border-gray-200 dark:border-gray-600 outline-none rounded-lg pl-10 pr-4 py-2 text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all" value={appSearchQuery} onChange={(e) => setAppSearchQuery(e.target.value)} />
                  </div>
               ) : (
-                 <p className="text-sm text-[#64748B] font-medium">
+                 <p className="text-sm text-[#64748B] dark:text-gray-400 font-medium">
                    {selectedOppId 
                      ? "Detail Overview" 
                      : (user ? `Welcome back, ${profile?.name || user.displayName || 'Student'}` : 'Welcome to YuvaHub')

--- a/src/components/Tabs/Settings.tsx
+++ b/src/components/Tabs/Settings.tsx
@@ -13,22 +13,21 @@ export default function SettingsTab() {
   const [privWins, setPrivWins] = useState(true);
 
   if (!user) {
-    return <div className="p-12 text-center text-gray-500">Please sign in to access settings.</div>;
+    return <div className="p-12 text-center text-gray-500 dark:text-gray-400">Please sign in to access settings.</div>;
   }
 
   return (
     <div className="max-w-4xl mx-auto space-y-8">
       <div>
-        <h2 className="text-3xl font-bold text-gray-900 mb-2">Settings</h2>
-        <p className="text-gray-500">Manage your account preferences and notifications.</p>
+        <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">Settings</h2>
+        <p className="text-gray-500 dark:text-gray-400">Manage your account preferences and notifications.</p>
       </div>
 
       <div className="space-y-6">
-        {/* Notifications */}
-        <div className="clean-card p-6">
-          <div className="flex items-center gap-3 mb-6 pb-4 border-b border-gray-100">
+        <div className="clean-card p-6 dark:bg-gray-800 dark:border-gray-700">
+          <div className="flex items-center gap-3 mb-6 pb-4 border-b border-gray-100 dark:border-gray-700">
             <Bell className="w-5 h-5 text-gray-400" />
-            <h3 className="text-lg font-semibold text-gray-900">Email Notifications</h3>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Email Notifications</h3>
           </div>
           <div className="space-y-4">
             <ToggleOption label="New personalized matches" checked={notiMatches} onChange={setNotiMatches} />
@@ -38,11 +37,10 @@ export default function SettingsTab() {
           </div>
         </div>
 
-        {/* Privacy */}
-        <div className="clean-card p-6">
-          <div className="flex items-center gap-3 mb-6 pb-4 border-b border-gray-100">
+        <div className="clean-card p-6 dark:bg-gray-800 dark:border-gray-700">
+          <div className="flex items-center gap-3 mb-6 pb-4 border-b border-gray-100 dark:border-gray-700">
             <Lock className="w-5 h-5 text-gray-400" />
-            <h3 className="text-lg font-semibold text-gray-900">Privacy</h3>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Privacy</h3>
           </div>
           <div className="space-y-4">
             <ToggleOption label="Show profile in mentor directory" checked={privDirectory} onChange={setPrivDirectory} />
@@ -50,19 +48,18 @@ export default function SettingsTab() {
           </div>
         </div>
 
-        {/* Account */}
-        <div className="clean-card p-6 border-red-100">
-          <div className="flex items-center gap-3 mb-6 pb-4 border-b border-gray-100">
+        <div className="clean-card p-6 border-red-100 dark:bg-gray-800 dark:border-gray-700">
+          <div className="flex items-center gap-3 mb-6 pb-4 border-b border-gray-100 dark:border-gray-700">
             <UserX className="w-5 h-5 text-red-500" />
-            <h3 className="text-lg font-semibold text-gray-900">Account Control</h3>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Account Control</h3>
           </div>
           <div className="space-y-4">
             <button className="clean-btn-outline w-full sm:w-auto px-6 py-2">Change Password</button>
-            <div className="pt-4 mt-4 border-t border-gray-100">
+            <div className="pt-4 mt-4 border-t border-gray-100 dark:border-gray-700">
               <button className="px-6 py-2 bg-red-50 text-red-600 font-medium rounded-lg hover:bg-red-100 transition-colors">
                 Delete Account
               </button>
-              <p className="text-xs text-gray-500 mt-2">This action is permanent and cannot be undone.</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">This action is permanent and cannot be undone.</p>
             </div>
           </div>
         </div>
@@ -74,10 +71,10 @@ export default function SettingsTab() {
 function ToggleOption({ label, checked, onChange }: { label: string, checked: boolean, onChange: (c: boolean) => void }) {
   return (
     <div className="flex items-center justify-between">
-      <span className="text-gray-700 font-medium">{label}</span>
+      <span className="text-gray-700 dark:text-gray-300 font-medium">{label}</span>
       <button 
         onClick={() => onChange(!checked)}
-        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${checked ? 'bg-blue-600' : 'bg-gray-200'}`}
+        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${checked ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-600'}`}
       >
         <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${checked ? 'translate-x-6' : 'translate-x-1'}`} />
       </button>

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -22,6 +22,8 @@ interface AppContextType {
   setSelectedOppId: (id: string | null) => void;
   viewOpportunity: (id: string, title?: string) => void;
   clearSelectedOpportunity: () => void;
+  theme: 'light' | 'dark';
+  toggleTheme: () => void;
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
@@ -35,14 +37,26 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   const [backendReady, setBackendReady] = useState(false);
   const [lastSyncedTime, setLastSyncedTime] = useState(new Date().toLocaleTimeString());
   const [appSearchQuery, setAppSearchQuery] = useState('');
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    const savedTheme = localStorage.getItem('yuvahub-theme');
+    return savedTheme === 'dark' ? 'dark' : 'light';
+  });
 
-  // Routing state
   const [selectedOppId, setSelectedOppId] = useState<string | null>(() => {
     const oppMatch = window.location.pathname.match(/^\/opportunity\/([^/]+)/);
     return oppMatch ? oppMatch[1] : null;
   });
 
-  // Verify API integrity and monitor backend readiness
+  useEffect(() => {
+    const root = window.document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('yuvahub-theme', theme);
+  }, [theme]);
+
   useEffect(() => {
     const verifyFeedEndpoint = async () => {
       try {
@@ -71,7 +85,6 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     return () => clearInterval(interval);
   }, []);
 
-  // Listen to popstate changes (browser forward/back navigation)
   useEffect(() => {
     const handleLocationChange = () => {
       const oppMatch = window.location.pathname.match(/^\/opportunity\/([^/]+)/);
@@ -87,7 +100,6 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     };
   }, []);
 
-  // Firebase auth sync
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
       setUser(currentUser);
@@ -145,6 +157,10 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     return () => unsubscribe();
   }, []);
 
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
   const viewOpportunity = (id: string, title?: string) => {
     const cleanTitle = title 
       ? title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "")
@@ -175,7 +191,9 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       selectedOppId,
       setSelectedOppId,
       viewOpportunity,
-      clearSelectedOpportunity
+      clearSelectedOpportunity,
+      theme,
+      toggleTheme
     }}>
       {children}
     </AppContext.Provider>

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 @import "tailwindcss";
-
+@custom-variant dark (&:where(.dark, .dark *));
 @theme {
   --color-primary: #2563eb;
   --color-primary-light: #EFF6FF;
@@ -33,7 +33,7 @@
 
 @layer base {
   body {
-    @apply bg-white text-[var(--color-text-main)] font-sans antialiased;
+    @apply bg-white text-[var(--color-text-main)] font-sans antialiased transition-colors duration-300 dark:bg-gray-900 dark:text-gray-100;
   }
 }
 


### PR DESCRIPTION
## Description
This PR resolves #1  by implementing a global Dark/Light theme toggle feature. It improves application accessibility, readability, and overall user experience by allowing users to seamlessly switch themes based on their environmental lighting.

## Proposed Changes
* **Theme Toggle Component:** Added a user-friendly toggle button in the navigation/header to switch between Light and Dark modes.
* **State Persistence:** Integrated `localStorage` to save the user's theme preference, ensuring it persists across browser sessions and page reloads.
* **Global Styling & Components:** Updated CSS/styles across all components to ensure uniform colors, contrast, and readability in both modes.
* **Smooth Transitions:** Added CSS transitions to make the switch between light and dark themes visually smooth and appealing.

## Benefits
* Significantly improves accessibility and usability in both daytime and low-light environments.
* Modernizes the UI with a customizable interface.
* Retains user preferences automatically.

## Behavioral / Visual Changes
* A theme toggle icon (e.g., Sun/Moon) is now visible in the layout.
* Clicking the toggle instantly updates the application colors with a smooth transition effect.

### Demo

https://github.com/user-attachments/assets/d70d5c37-8cae-435a-8be0-f4008a18fc00



> **Note to Maintainer:** I am a contributor participating in **ECSoC'26**. Please let me know if any adjustments are needed during your review!

Hi @uditt490-pixel  could you please review this merged PR for a potential bonus label based on the metrics below? 
<img width="662" height="301" alt="labels" src="https://github.com/user-attachments/assets/b8f3611b-6f8e-47b0-93b0-ef1909a36cff" />

Thanks! 