### PR TITLE
fix: add missing notifications read-all API endpoint

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1468,6 +1468,14 @@ Return JSON strictly in this format:
     res.json({ success: true });
   });
 
+  app.post("/api/v1/notifications/read-all", (req, res) => {
+  notifications.forEach((notification) => {
+    notification.read = true;
+  });
+
+  res.json({ success: true });
+});
+
   // Health check
   app.get("/api/v1/health", (req, res) => {
     res.json({ 


### PR DESCRIPTION
## Summary

This PR adds the missing `POST /api/v1/notifications/read-all` endpoint to the Node.js server.

The Notifications dropdown already invokes this endpoint when the **"Mark all as read"** button is clicked. However, since the endpoint was not implemented on the backend, the request resulted in a **404 Not Found** response and the action failed.

This change implements the missing endpoint and updates the in-memory notifications list by marking every notification as read before returning a successful response.

---

## Changes Made

- Added `POST /api/v1/notifications/read-all` endpoint in `server.ts`
- Marks all notifications as `read: true`
- Returns a successful JSON response

---

## Testing

- Started the application locally (`npm run dev`)
- Opened the Notifications dropdown
- Clicked **Mark all as read**
- Verified the request now returns **HTTP 200 OK**
- Confirmed the notification state updates successfully without any 404 errors

---

## Before

- `POST /api/v1/notifications/read-all` returned **404 Not Found**
- "Mark all as read" could not complete successfully

## After

- `POST /api/v1/notifications/read-all` returns **200 OK**
- Notifications are successfully marked as read

---

## Screenshots

Attached a Network tab screenshot showing the successful `POST /api/v1/notifications/read-all` request (`200 OK`).
<img width="2725" height="877" alt="Screenshot 2026-07-17 010358" src="https://github.com/user-attachments/assets/429e7f91-0476-4d2e-9f00-055211b69cf7" />