### PR TITLE
[Feature]: implement circuit breakers for external API integrations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "meilisearch": "^0.59.0",
         "mongodb": "^7.2.0",
         "motion": "^12.23.24",
+        "opossum": "^10.0.0",
         "rate-limit-redis": "^5.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -46,6 +47,7 @@
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^22.14.0",
+        "@types/opossum": "^8.1.9",
         "autoprefixer": "^10.4.21",
         "esbuild": "^0.28.0",
         "tailwindcss": "^4.1.14",
@@ -2396,6 +2398,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/opossum": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/opossum/-/opossum-8.1.9.tgz",
+      "integrity": "sha512-Jm/tYxuJFefiwRYs+/EOsUP3ktk0c8siMgAHPLnA4PXF4wKghzcjqf88dY+Xii5jId5Txw4JV0FMKTpjbd7KJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -5643,6 +5655,15 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/opossum": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-10.0.0.tgz",
+      "integrity": "sha512-sghtqL8Usj+et06Zui0nyn0R6FFsl7cyuoU+d7MctYU0nbS7Htzjleh+tWohFqk1Rp1srrFwbFa8Vxd0O64w6A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^26 || ^24 || ^22"
       }
     },
     "node_modules/p-retry": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "meilisearch": "^0.59.0",
     "mongodb": "^7.2.0",
     "motion": "^12.23.24",
+    "opossum": "^10.0.0",
     "rate-limit-redis": "^5.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -54,6 +55,7 @@
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^22.14.0",
+    "@types/opossum": "^8.1.9",
     "autoprefixer": "^10.4.21",
     "esbuild": "^0.28.0",
     "tailwindcss": "^4.1.14",

--- a/src/services/circuitBreaker.ts
+++ b/src/services/circuitBreaker.ts
@@ -1,0 +1,29 @@
+import CircuitBreaker from 'opossum';
+
+export function createBreaker<T extends (...args: any[]) => Promise<any>>(
+  action: T,
+  options: CircuitBreaker.Options = {},
+  name: string = 'Unnamed Breaker'
+): CircuitBreaker {
+  const defaultOptions: CircuitBreaker.Options = {
+    timeout: 10000, // 10 seconds
+    errorThresholdPercentage: 50, // 50% errors trips the circuit
+    resetTimeout: 30000, // wait 30 seconds before trying again
+  };
+
+  const finalOptions = { ...defaultOptions, ...options };
+  const breaker = new CircuitBreaker(action, finalOptions);
+
+  breaker.on('open', () => console.warn(`[CircuitBreaker] ${name} circuit OPEN`));
+  breaker.on('halfOpen', () => console.warn(`[CircuitBreaker] ${name} circuit HALF_OPEN`));
+  breaker.on('close', () => console.log(`[CircuitBreaker] ${name} circuit CLOSED`));
+  breaker.on('fallback', (result, err) => {
+    if (err) {
+      console.warn(`[CircuitBreaker] ${name} fallback triggered. Error:`, err.message);
+    } else {
+      console.warn(`[CircuitBreaker] ${name} fallback triggered.`);
+    }
+  });
+
+  return breaker;
+}

--- a/src/services/dnl/circuitBreakerTest.ts
+++ b/src/services/dnl/circuitBreakerTest.ts
@@ -1,0 +1,33 @@
+import { DNLDispatcher } from './scheduler';
+import { DevpostAdapter } from './adapters/DevpostAdapter';
+
+async function testCircuitBreaker() {
+  console.log('--- Circuit Breaker Manual Test ---');
+  
+  // We don't need a real DB connection for this test as the HTTP fetch happens before DB insertion
+  const mockDb = { collection: () => ({ insertOne: () => {}, find: () => ({ toArray: () => [] }) }) };
+  const dispatcher = new DNLDispatcher(mockDb);
+  const adapter = new DevpostAdapter();
+  
+  dispatcher.registerAdapter(adapter);
+
+  // An endpoint that is guaranteed to fail or refuse connection
+  const badUrl = 'http://localhost:9999/refused-endpoint';
+
+  console.log(`Starting repeated requests to a failing endpoint: ${badUrl}\n`);
+
+  for (let i = 1; i <= 6; i++) {
+    console.log(`\nAttempt ${i}:`);
+    
+    // We intentionally ignore errors in the test script loop
+    await dispatcher.runScrape(adapter, badUrl).catch(() => {});
+    
+    // Small delay between requests
+    await new Promise(res => setTimeout(res, 500));
+  }
+  
+  console.log('\nNotice how after consecutive failures, the CircuitBreaker logs that it is OPEN.');
+  console.log('Subsequent requests in this state will instantly use the fallback without waiting for the fetch timeout.');
+}
+
+testCircuitBreaker().catch(console.error);

--- a/src/services/dnl/scheduler.ts
+++ b/src/services/dnl/scheduler.ts
@@ -1,11 +1,13 @@
 import { IOpportunityAdapter } from './types';
 import { ingestOpportunities } from './deduplicator';
 import { logTelemetry } from './metrics';
+import { createBreaker } from '../circuitBreaker';
 
 export class DNLDispatcher {
   private db: any;
   private adapters: IOpportunityAdapter[] = [];
   private intervalId: NodeJS.Timeout | null = null;
+  private breakers: Record<string, any> = {};
 
   constructor(db: any) {
     this.db = db;
@@ -13,6 +15,46 @@ export class DNLDispatcher {
 
   registerAdapter(adapter: IOpportunityAdapter) {
     this.adapters.push(adapter);
+  }
+
+  private getBreaker(sourceName: string) {
+    if (!this.breakers[sourceName]) {
+      const fetchCb = async (url: string) => {
+        const fetchStart = performance.now();
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        
+        let ttfb = 0;
+        // In Node.js environment, response.body might not have getReader if it's node-fetch.
+        // We'll do a simple fallback if reader is not available.
+        if (response.body && typeof (response.body as any).getReader === 'function') {
+          const reader = (response.body as any).getReader();
+          await reader.read();
+          ttfb = Math.round(performance.now() - fetchStart);
+        } else {
+          ttfb = Math.round(performance.now() - fetchStart);
+        }
+        
+        const text = await response.text();
+        return { text, ttfb };
+      };
+      
+      const breaker = createBreaker(
+        fetchCb,
+        { timeout: 10000, errorThresholdPercentage: 50, resetTimeout: 30000 },
+        sourceName
+      );
+      
+      breaker.fallback((url, err) => {
+        // Return empty payload array if circuit opens or fetch fails
+        return { text: "[]", ttfb: 0 };
+      });
+
+      this.breakers[sourceName] = breaker;
+    }
+    return this.breakers[sourceName];
   }
 
   // Orchestrate a single run for an adapter with its payload/url
@@ -25,20 +67,10 @@ export class DNLDispatcher {
 
     try {
       if (typeof fetchUrlOrPayload === 'string') {
-        // Measure TTFB by fetching from URL
-        const fetchStart = performance.now();
-        const response = await fetch(fetchUrlOrPayload);
-        const reader = response.body?.getReader();
-        if (reader) {
-          await reader.read(); // Read first byte/chunk
-          ttfb = Math.round(performance.now() - fetchStart);
-        } else {
-          ttfb = Math.round(performance.now() - fetchStart);
-        }
-        
-        // Fetch full text
-        const text = await response.text();
-        rawPayload = JSON.parse(text);
+        const breaker = this.getBreaker(adapter.sourceName);
+        const result = await breaker.fire(fetchUrlOrPayload);
+        ttfb = result.ttfb;
+        rawPayload = JSON.parse(result.text);
       } else {
         // Static/mock payload
         const simulatedDelay = Math.floor(Math.random() * 50) + 10; // 10ms-60ms

--- a/src/services/toxicity.ts
+++ b/src/services/toxicity.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { GoogleGenAI } from '@google/genai';
+import { createBreaker } from './circuitBreaker';
 
 // Simple local keyword-based check for quick offline toxicity classification
 const TOXIC_KEYWORDS = [
@@ -7,6 +8,22 @@ const TOXIC_KEYWORDS = [
   'motherfucker', 'retard', 'faggot', 'nigger', 'idiot', 'moron', 'kill yourself',
   'die', 'hate you'
 ];
+
+const geminiBreaker = createBreaker(
+  async (genAI: GoogleGenAI, text: string) => {
+    return await genAI.models.generateContent({
+      model: "gemini-2.5-flash", // Using a fast, standard model
+      contents: `Classify if the following text is toxic, abusive, hateful, or highly inappropriate. Respond with ONLY 'toxic' or 'clean' (in lowercase): \n\n"${text}"`
+    });
+  },
+  { timeout: 5000, errorThresholdPercentage: 50, resetTimeout: 30000 },
+  'Gemini AI'
+);
+
+geminiBreaker.fallback((genAI, text, err) => {
+  // If Gemini fails or circuit is open, we fallback to 'clean' to not block users unnecessarily
+  return { text: 'clean' };
+});
 
 /**
  * Checks if a string contains toxic content.
@@ -30,11 +47,7 @@ export async function isToxic(text: string, genAI?: GoogleGenAI | null): Promise
   // 2. Google Gemini fallback if instance is available
   if (genAI) {
     try {
-      const response = await genAI.models.generateContent({
-        model: "gemini-2.5-flash", // Using a fast, standard model
-        contents: `Classify if the following text is toxic, abusive, hateful, or highly inappropriate. Respond with ONLY 'toxic' or 'clean' (in lowercase): \n\n"${text}"`
-      });
-
+      const response = await geminiBreaker.fire(genAI, text);
       const responseText = (response.text || '').toLowerCase().trim();
       console.log(`[Toxicity Checker] Gemini model response: "${responseText}"`);
       return responseText.includes('toxic');


### PR DESCRIPTION
- closes #103

### Description
This PR integrates the `opossum` circuit breaker library to protect the platform from thread exhaustion and cascading failures caused by external service downtime or rate-limiting.

All outgoing requests to the Gemini AI API and external DNL scrapers (Devpost, Internshala) are now wrapped in a protective circuit breaker pattern.

### Key Changes
- **Added `circuitBreaker.ts` Utility:** Centralized wrapper for instantiating circuit breakers with consistent defaults (10s timeout, 50% error threshold, 30s reset cooldown).
- **Gemini API Protection (`toxicity.ts`):** Wrapped the `generateContent` call. If the API fails or the circuit opens, the system safely falls back to classifying the text as `clean` rather than blocking user operations.
- **DNL Scraper Protection (`scheduler.ts`):** Added a breaker registry keyed by adapter names. If a target URL is unreachable or times out, the circuit opens and returns an empty dataset (`[]`). This prevents the scraper loop from crashing or dragging down server performance.
- **Added Manual Test Script:** Included `circuitBreakerTest.ts` to simulate failure scenarios and verify fallback mechanisms.

## Motivation and Context
Previously, if an external dependency went down, the backend would wait for requests to time out, keeping connections open and quickly consuming server resources. Under heavy load, a single degraded service could cause platform-wide timeouts. 

By failing fast and gracefully degrading features, this change ensures that core platform operations remain stable and responsive even when third-party services are disrupted.

### How To Test
You can manually test the circuit breaker's behavior (opening the circuit and triggering the fallback) by running the included test script:
```bash
npx tsx src/services/dnl/circuitBreakerTest.ts
