### PR TITLE
feat: add missing legal and policy page components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,10 @@ import SplashAuth from './components/SplashAuth';
 import Security from './components/Tabs/Security';
 import Legal from './components/Tabs/Legal';
 import Support from './components/Tabs/Support';
+import Privacy from './pages/Privacy';
+import Terms from './pages/Terms';
+import Cookies from './pages/Cookies';
+import Guidelines from './pages/Guidelines';
 
 function App() {
   const {

--- a/src/pages/Cookies.tsx
+++ b/src/pages/Cookies.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const Cookies: React.FC = () => {
+  return (
+    <div className="p-8 max-w-4xl mx-auto">
+      <h1 className="text-3xl font-bold mb-6">Cookie Policy</h1>
+      <p className="text-gray-600 dark:text-gray-300">
+        This is a placeholder for the Cookie Policy. We use cookies to improve your experience.
+      </p>
+    </div>
+  );
+};
+
+export default Cookies;

--- a/src/pages/Guidelines.tsx
+++ b/src/pages/Guidelines.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const Guidelines: React.FC = () => {
+  return (
+    <div className="p-8 max-w-4xl mx-auto">
+      <h1 className="text-3xl font-bold mb-6">Community Guidelines</h1>
+      <p className="text-gray-600 dark:text-gray-300">
+        This is a placeholder for the Community Guidelines. Please be respectful to others.
+      </p>
+    </div>
+  );
+};
+
+export default Guidelines;

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const Privacy: React.FC = () => {
+  return (
+    <div className="p-8 max-w-4xl mx-auto">
+      <h1 className="text-3xl font-bold mb-6">Privacy Policy</h1>
+      <p className="text-gray-600 dark:text-gray-300">
+        This is a placeholder for the Privacy Policy. We take your privacy seriously.
+      </p>
+    </div>
+  );
+};
+
+export default Privacy;

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const Terms: React.FC = () => {
+  return (
+    <div className="p-8 max-w-4xl mx-auto">
+      <h1 className="text-3xl font-bold mb-6">Terms of Service</h1>
+      <p className="text-gray-600 dark:text-gray-300">
+        This is a placeholder for the Terms of Service. By using our platform, you agree to these terms.
+      </p>
+    </div>
+  );
+};
+
+export default Terms;


### PR DESCRIPTION
## 📝 Overview
This pull request resolves TypeScript compilation errors in `src/App.tsx` caused by missing component definitions for several legal and policy routes.

While the application routes were previously referencing `Privacy`, `Terms`, `Cookies`, and `Guidelines`, the actual React components were never imported or created in the codebase, leading to failed builds.

## 🛠️ Detailed Changes
- **Component Creation:** Created four new placeholder React components inside the `src/pages/` directory:
  - `src/pages/Privacy.tsx`
  - `src/pages/Terms.tsx`
  - `src/pages/Cookies.tsx`
  - `src/pages/Guidelines.tsx`
- Each new page features a responsive UI container with a styled header and simple placeholder text.
- **Routing Fixes:** Successfully imported these four new pages at the top of the main `src/App.tsx` file, fulfilling the required component mappings in the route handler.

## 🐛 Impact & Benefits
- Fixes immediate compiler and runtime errors associated with unresolved component imports in the routing tree.
- Establishes the correct directory structure (`src/pages/`) and foundational files for future legal page copy to be added without breaking the build.

## 🔗 Related Issues
Closes https://github.com/uditt490-pixel/YuvaHub/issues/121