### PR TITLE
fix: restrict mock authentication to development environments

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -4,28 +4,48 @@ import { getAuth } from 'firebase-admin/auth';
 
 let isFirebaseInitialized = false;
 
-// Initialize Firebase Admin (with mock/fallback if credentials aren't present)
+const isDevelopment = process.env.NODE_ENV === 'development';
+const mockAuthEnabled = process.env.ENABLE_MOCK_AUTH === 'true';
+const mockValidToken = process.env.MOCK_VALID_TOKEN || 'MOCK_VALID_TOKEN';
+
+// Initialize Firebase Admin
 try {
   if (process.env.FIREBASE_SERVICE_ACCOUNT_BASE64) {
-    const serviceAccount = JSON.parse(Buffer.from(process.env.FIREBASE_SERVICE_ACCOUNT_BASE64, 'base64').toString('utf8'));
+    const serviceAccount = JSON.parse(
+      Buffer.from(
+        process.env.FIREBASE_SERVICE_ACCOUNT_BASE64,
+        'base64',
+      ).toString('utf8'),
+    );
+
     initializeApp({
-      credential: cert(serviceAccount)
+      credential: cert(serviceAccount),
     });
+
     isFirebaseInitialized = true;
-    console.log("[Auth] Firebase Admin initialized with provided service account.");
+    console.log(
+      '[Auth] Firebase Admin initialized with provided service account.',
+    );
   } else if (process.env.FIREBASE_PROJECT_ID) {
-     initializeApp({
-        projectId: process.env.FIREBASE_PROJECT_ID,
-     });
-     isFirebaseInitialized = true;
-     console.log("[Auth] Firebase Admin initialized with Application Default Credentials / Project ID.");
+    initializeApp({
+      projectId: process.env.FIREBASE_PROJECT_ID,
+    });
+
+    isFirebaseInitialized = true;
+    console.log(
+      '[Auth] Firebase Admin initialized with Application Default Credentials / Project ID.',
+    );
+  } else if (isDevelopment && mockAuthEnabled) {
+    console.warn(
+      '[Auth] WARNING: Firebase credentials not found. Mock authentication is ENABLED for development.',
+    );
   } else {
-    // Mock initialization for offline development
-    console.warn("[Auth] WARNING: No Firebase Admin credentials found. Using MOCK auth verification for development.");
-    // In a real scenario, this shouldn't be used in production.
+    console.warn(
+      '[Auth] Firebase credentials not found. Mock authentication is disabled.',
+    );
   }
 } catch (error) {
-  console.error("[Auth] Firebase Admin initialization error:", error);
+  console.error('[Auth] Firebase Admin initialization error:', error);
 }
 
 // Extend Request interface to include the user
@@ -40,8 +60,11 @@ declare global {
 export const authenticateUser = (dbCommand: any) => {
   return async (req: Request, res: Response, next: NextFunction) => {
     const authHeader = req.headers.authorization;
+
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return res.status(401).json({ error: 'Unauthorized: Missing or invalid token format' });
+      return res.status(401).json({
+        error: 'Unauthorized: Missing or invalid token format',
+      });
     }
 
     const token = authHeader.split(' ')[1];
@@ -49,29 +72,35 @@ export const authenticateUser = (dbCommand: any) => {
     try {
       let decodedToken: any = null;
 
-      // Check if we are running in mock mode
       if (!isFirebaseInitialized) {
-         // MOCK VERIFICATION
-         if (token === "MOCK_VALID_TOKEN") {
-             decodedToken = {
-                 uid: "mock_user_123",
-                 email: "mock@example.com",
-                 name: "Mock User"
-             };
-         } else {
-             throw new Error("Invalid mock token");
-         }
+        if (!(isDevelopment && mockAuthEnabled)) {
+          return res.status(503).json({
+            error:
+              'Authentication service unavailable. Firebase Admin is not configured.',
+          });
+        }
+
+        console.warn('[Auth] Using mock authentication.');
+
+        if (token === mockValidToken) {
+          decodedToken = {
+            uid: 'mock_user_123',
+            email: 'mock@example.com',
+            name: 'Mock User',
+          };
+        } else {
+          throw new Error('Invalid mock token');
+        }
       } else {
-         decodedToken = await getAuth().verifyIdToken(token);
+        decodedToken = await getAuth().verifyIdToken(token);
       }
 
       req.user = decodedToken;
 
-      // JIT Profile Creation (Eventual Consistency with Upsert)
       if (dbCommand) {
         try {
           const usersCollection = dbCommand.collection('users');
-          
+
           await usersCollection.findOneAndUpdate(
             { firebaseUid: decodedToken.uid },
             {
@@ -80,30 +109,38 @@ export const authenticateUser = (dbCommand: any) => {
                 email: decodedToken.email,
                 name: decodedToken.name || '',
                 picture: decodedToken.picture || '',
-                created_at: new Date()
-              }
+                created_at: new Date(),
+              },
             },
-            { upsert: true, returnDocument: 'after' }
+            {
+              upsert: true,
+              returnDocument: 'after',
+            },
           );
         } catch (dbError) {
-          console.error('[Auth] Error during JIT user profile creation:', dbError);
-          // Depending on requirements, we could block the request here or let it pass 
-          // (failing open if it's a transient DB error). We'll let it pass for now.
+          console.error(
+            '[Auth] Error during JIT user profile creation:',
+            dbError,
+          );
         }
       }
 
       next();
     } catch (error) {
       console.error('[Auth] Token verification failed:', error);
-      return res.status(401).json({ error: 'Unauthorized: Invalid token' });
+      return res.status(401).json({
+        error: 'Unauthorized: Invalid token',
+      });
     }
   };
 };
 
 export const deleteFirebaseUser = async (uid: string) => {
-    if (isFirebaseInitialized) {
-        await getAuth().deleteUser(uid);
-    } else {
-        console.warn(`[Auth] Mock mode: Firebase user ${uid} deletion skipped.`);
-    }
+  if (isFirebaseInitialized) {
+    await getAuth().deleteUser(uid);
+  } else if (isDevelopment && mockAuthEnabled) {
+    console.warn(
+      `[Auth] Mock mode: Firebase user ${uid} deletion skipped.`,
+    );
+  }
 };


### PR DESCRIPTION
## Summary

Closes #152

This PR improves the security of the authentication middleware by restricting mock authentication to development environments and making it configurable through environment variables.

## Changes Made

* Restricted mock authentication to `NODE_ENV=development`.
* Added support for enabling/disabling mock authentication using the `ENABLE_MOCK_AUTH` environment variable.
* Replaced the hardcoded mock token with the configurable `MOCK_VALID_TOKEN` environment variable.
* Added clear warning messages when mock authentication is enabled.
* Prevented mock authentication from being used when Firebase Admin is not configured outside development environments.
* Returned a `503 Service Unavailable` response when Firebase authentication is unavailable and mock mode is disabled.
* Updated mock user deletion logging to execute only when development mock mode is enabled.

## Benefits

* Improves application security by preventing accidental use of mock authentication in production.
* Makes development authentication configurable without modifying source code.
* Provides clearer diagnostics through development-only warning messages.
* Aligns the authentication flow with security best practices.

## Testing

* Verified mock authentication works only when `NODE_ENV=development` and `ENABLE_MOCK_AUTH=true`.
* Verified mock authentication is rejected when disabled or in production.
* Verified Firebase authentication continues to function normally when Firebase Admin is configured.
* Verified a `503` response is returned when Firebase is unavailable and mock authentication is disabled.
* Confirmed existing JIT user profile creation logic remains unchanged.
