### PR TITLE
feat: add event waitlist schema and firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -38,5 +38,12 @@ service cloud.firestore {
       allow update: if isOwner(resource.data.uid);
       allow delete: if isOwner(resource.data.uid);
     }
+
+    match /event_waitlists/{waitlistId} {
+      allow read: if isAuthenticated() && resource.data.userId == request.auth.uid;
+      allow create: if isAuthenticated() && request.resource.data.userId == request.auth.uid;
+      allow update: if isOwner(resource.data.userId);
+      allow delete: if isOwner(resource.data.userId);
+    }
   }
 }

--- a/src/models/eventWaitlistSchema.ts
+++ b/src/models/eventWaitlistSchema.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+
+export const WaitlistStatusSchema = z.enum([
+  "pending",
+  "approved",
+  "rejected",
+]);
+
+export type WaitlistStatus = z.infer<typeof WaitlistStatusSchema>;
+
+export const EventWaitlistSchema = z.object({
+  opportunityId: z.string(),
+  userId: z.string(),
+  status: WaitlistStatusSchema.default("pending"),
+  joinedAt: z.date().default(() => new Date()),
+  notified: z.boolean().default(false),
+  updatedAt: z.date().default(() => new Date()),
+});
+
+export type EventWaitlist = z.infer<typeof EventWaitlistSchema>;
+
+export interface EventWaitlistDocument {
+  _id?: string;
+  
+  /**
+   * Opportunity / Event ID
+   */
+  opportunityId: string;
+  
+  /**
+   * User ID of the waitlisted member
+   */
+  userId: string;
+  
+  /**
+   * Current workflow state
+   */
+  status: WaitlistStatus;
+  
+  /**
+   * Whether the user has been notified of approval
+   */
+  notified: boolean;
+  
+  joinedAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Factory helper
+ * Creates a clean event waitlist document
+ */
+export function createEventWaitlistDocument(
+  data: Partial<EventWaitlistDocument>
+): EventWaitlistDocument {
+  const now = new Date();
+  
+  return {
+    opportunityId: data.opportunityId || "",
+    userId: data.userId || "",
+    status: data.status || "pending",
+    notified: data.notified || false,
+    joinedAt: data.joinedAt || now,
+    updatedAt: data.updatedAt || now,
+  };
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces the foundational data structures and database rules needed to support the waitlist functionality for events and opportunities.

### Changes
- **Data Models / Schemas**: Created a new `EventWaitlistSchema` using Zod in `src/models/eventWaitlistSchema.ts` that includes fields for user, opportunity reference, join timestamps, and approval status tracking.
- **Firebase Rules**: Updated `firestore.rules` to include a new match block for `/event_waitlists/{waitlistId}`, enabling users to safely join a waitlist with proper authorization.

## Type of Change

- [x] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #162

## Testing

Verified that the Zod schema matches project conventions and that the Firestore rules provide necessary granular access without breaking other components.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A - Backend changes only

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
