### PR TITLE
fix: add start date and end date validation for event creation

### DIFF
--- a/src/components/Tabs/SubmitOpportunity.tsx
+++ b/src/components/Tabs/SubmitOpportunity.tsx
@@ -17,6 +17,8 @@ export default function SubmitOpportunity() {
     location: '',
     link: '',
     deadline: '',
+    startDate: '',
+    endDate: '',
     tags: '',
     email: '',
     confirmed: false
@@ -29,6 +31,13 @@ export default function SubmitOpportunity() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!formData.confirmed || loading) return;
+
+    if (formData.startDate && formData.endDate) {
+      if (new Date(formData.endDate) < new Date(formData.startDate)) {
+        setSubmitError("End date cannot be earlier than start date.");
+        return;
+      }
+    }
 
     setLoading(true);
     setSubmitError(null);
@@ -49,6 +58,8 @@ export default function SubmitOpportunity() {
         },
         link: formData.link,
         deadline: formData.deadline,
+        startDate: formData.startDate,
+        endDate: formData.endDate,
         tags: tagsArray,
         contactEmail: formData.email,
         status: 'pending_review',
@@ -58,7 +69,7 @@ export default function SubmitOpportunity() {
       
       setSuccess(true);
       setFormData({
-        type: 'Internship', title: '', org: '', desc: '', year: 'Any', field: 'Any', location: '', link: '', deadline: '', tags: '', email: '', confirmed: false
+        type: 'Internship', title: '', org: '', desc: '', year: 'Any', field: 'Any', location: '', link: '', deadline: '', startDate: '', endDate: '', tags: '', email: '', confirmed: false
       });
     } catch {
       setSubmitError('Unable to submit the opportunity. Please try again.');
@@ -174,6 +185,19 @@ export default function SubmitOpportunity() {
             <input type="date" className="clean-input w-full p-3" value={formData.deadline} onChange={e => setFormData({...formData, deadline: e.target.value})} />
           </div>
         </div>
+
+        {(formData.type === 'Hackathon' || formData.type === 'Event' || formData.type === 'Program') && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 pt-4 border-t border-gray-100">
+            <div className="space-y-1">
+              <label className="text-sm font-semibold text-gray-700">Start Date</label>
+              <input type="date" className="clean-input w-full p-3" value={formData.startDate} onChange={e => setFormData({...formData, startDate: e.target.value})} />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-semibold text-gray-700">End Date</label>
+              <input type="date" className="clean-input w-full p-3" value={formData.endDate} onChange={e => setFormData({...formData, endDate: e.target.value})} />
+            </div>
+          </div>
+        )}
 
         <div className="pt-4 border-t border-gray-100 space-y-4">
           <div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export interface Opportunity {
   description: string;
   location: string;
   deadline: string; // ISO date string
+  startDate?: string;
+  endDate?: string;
   link: string;
   tags: string[];
   contactEmail: string;


### PR DESCRIPTION

# Pull Request

## Description

This pull request resolves an issue with the event creation form where users were unable to submit start and end dates for their events, and date validation was missing. The `SubmitOpportunity` component and `Opportunity` type definition have been updated to support `startDate` and `endDate`.

### Changes
- **types.ts**: Added optional `startDate` and `endDate` fields to the `Opportunity` interface.
- **SubmitOpportunity.tsx**:
  - Expanded `formData` state to track `startDate` and `endDate`.
  - Added conditional form fields to collect Start Date and End Date if the submitted opportunity type is one of `Hackathon`, `Event`, or `Program`.
  - Implemented form validation logic in `handleSubmit` to verify that `endDate` is not chronologically earlier than `startDate`.
  - Updated the Firestore `addDoc` payload to include the new fields.

## Type of Change

- [ ] New Feature
- [ ] Documentation Update
- [x] Bug Fix
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #165

## Testing

Verified that selecting an event type reveals the start and end date inputs, and that submitting an end date preceding the start date correctly halts the submission and triggers a UI error message.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
