### PR TITLE
fix: remove duplicate EventBus connection declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test-scraper": "tsx tests/test-scraper.ts",
     "test-semantic-search": "tsx tests/test-semantic-search.ts",
     "test-auth": "tsx tests/test-jit-auth.ts",
-    "test-socket": "tsx tests/test-socket-fallback.ts"
+    "test-socket": "tsx tests/test-socket-fallback.ts",
+    "test-eventbus": "tsx tests/test-eventbus.ts"
   },
   "dependencies": {
     "@bull-board/api": "^8.1.2",

--- a/src/events/eventBus.ts
+++ b/src/events/eventBus.ts
@@ -4,7 +4,6 @@ const RABBITMQ_URL = process.env.RABBITMQ_URL || 'amqp://localhost';
 
 class EventBus {
   private connection: amqp.ChannelModel | null = null;
-  private connection: any | null = null;
   private channel: amqp.Channel | null = null;
 
   async connect(): Promise<void> {

--- a/tests/test-eventbus.ts
+++ b/tests/test-eventbus.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert";
+import { createRequire } from "node:module";
+
+// Monkey-patch amqplib to intercept RabbitMQ connection logic before EventBus imports it
+const req = createRequire(import.meta.url);
+const amqplibMod = req("amqplib");
+
+// Track interactions for assertions
+let connectionEstablished = false;
+let connectionClosed = false;
+let channelCreated = false;
+let channelClosed = false;
+let publishedMessages: { exchange: string; routingKey: string; content: Buffer }[] = [];
+let subscribedQueues: { queue: string; exchange: string; routingKey: string; handler: Function }[] = [];
+let ackedMessages = 0;
+let nackedMessages = 0;
+
+// Mock Channel
+const mockChannel = {
+  assertExchange: async (exchange: string, type: string, options: any) => {},
+  assertQueue: async (queueName: string, options: any) => ({ queue: queueName }),
+  bindQueue: async (queue: string, exchange: string, routingKey: string) => {},
+  publish: (exchange: string, routingKey: string, content: Buffer, options: any) => {
+    publishedMessages.push({ exchange, routingKey, content });
+    return true;
+  },
+  consume: async (queue: string, handler: Function) => {
+    subscribedQueues.push({ queue, exchange: "domain_events", routingKey: "", handler });
+    return { consumerTag: "mock_tag" };
+  },
+  ack: (msg: any) => {
+    ackedMessages++;
+  },
+  nack: (msg: any, allUpTo: boolean, requeue: boolean) => {
+    nackedMessages++;
+  },
+  close: async () => {
+    channelClosed = true;
+  }
+};
+
+// Mock Connection
+const mockConnection = {
+  createChannel: async () => {
+    channelCreated = true;
+    return mockChannel;
+  },
+  close: async () => {
+    connectionClosed = true;
+  }
+};
+
+let shouldFailConnection = true;
+amqplibMod.connect = async (url: string) => {
+  if (shouldFailConnection) {
+    shouldFailConnection = false;
+    throw new Error("Simulated connection failure");
+  }
+  connectionEstablished = true;
+  return mockConnection;
+};
+
+// Now import eventBus dynamically so it uses the patched amqplib
+const { eventBus } = await import("../src/events/eventBus.js");
+
+async function runTests() {
+  console.log("Starting EventBus Regression Tests...");
+
+  // 1. Connection Failure Handling
+  try {
+    await eventBus.connect();
+    assert.fail("Should have thrown an error on connection failure");
+  } catch (err: any) {
+    assert.strictEqual(err.message, "Simulated connection failure", "EventBus should throw connection errors");
+  }
+
+  // 2. Successful Connection and Channel Creation
+  process.env.RABBITMQ_URL = "amqp://localhost";
+  await eventBus.connect();
+  assert.strictEqual(connectionEstablished, true, "EventBus should establish connection");
+  assert.strictEqual(channelCreated, true, "EventBus should create a channel");
+
+  // Idempotency check: calling connect again shouldn't recreate the connection
+  connectionEstablished = false;
+  await eventBus.connect();
+  assert.strictEqual(connectionEstablished, false, "EventBus should not reconnect if already connected");
+
+  // 3. Publish Message
+  const testEvent = { id: 123, type: "test" };
+  await eventBus.publish("test.routing.key", testEvent);
+  assert.strictEqual(publishedMessages.length, 1, "Should have published 1 message");
+  assert.strictEqual(publishedMessages[0].exchange, "domain_events", "Should publish to domain_events exchange");
+  assert.strictEqual(publishedMessages[0].routingKey, "test.routing.key", "Should use correct routing key");
+  assert.deepStrictEqual(JSON.parse(publishedMessages[0].content.toString()), testEvent, "Should serialize event payload correctly");
+
+  // 4. Subscribe and Acknowledge
+  let handledEvent = null;
+  await eventBus.subscribe("test_queue", "test.routing.key", async (event) => {
+    handledEvent = event;
+  });
+  assert.strictEqual(subscribedQueues.length, 1, "Should have subscribed to the queue");
+  assert.strictEqual(subscribedQueues[0].queue, "test_queue");
+
+  // Simulate receiving a message
+  const mockMsg = { content: Buffer.from(JSON.stringify(testEvent)) };
+  await subscribedQueues[0].handler(mockMsg);
+  assert.deepStrictEqual(handledEvent, testEvent, "Handler should receive the parsed event");
+  assert.strictEqual(ackedMessages, 1, "Message should be acknowledged after successful handling");
+
+  // 5. Subscribe and Negative Acknowledge (Nack) on Error
+  await eventBus.subscribe("fail_queue", "fail.routing.key", async (event) => {
+    throw new Error("Simulated processing error");
+  });
+  
+  const mockFailMsg = { content: Buffer.from(JSON.stringify(testEvent)) };
+  await subscribedQueues[1].handler(mockFailMsg);
+  assert.strictEqual(nackedMessages, 1, "Message should be negatively acknowledged on error");
+
+  // 6. Disconnect Cleans Resources
+  await eventBus.disconnect();
+  assert.strictEqual(channelClosed, true, "Channel should be closed");
+  assert.strictEqual(connectionClosed, true, "Connection should be closed");
+
+  // 7. Verify Unconnected State
+  try {
+    await eventBus.publish("test", {});
+    assert.fail("Should not allow publishing when disconnected");
+  } catch (err: any) {
+    assert.strictEqual(err.message, "EventBus is not connected", "Should throw when publishing while disconnected");
+  }
+
+  console.log("✅ All EventBus regression tests passed successfully.");
+}
+
+runTests().catch(err => {
+  console.error("❌ Test failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
# 🚀 Pull Request

📝 Summary

This PR fixes a TypeScript compilation issue in the EventBus class by removing the duplicate connection property declaration. The change preserves the existing strongly typed amqp.ChannelModel property and resolves duplicate identifier errors without affecting runtime behavior.

⸻

🔗 Related Issue

Closes #185

⸻

✨ Changes Made

* Removed the duplicate connection property declaration from src/events/eventBus.ts.
* Retained the correctly typed amqp.ChannelModel | null declaration.
* Kept the implementation minimal without changing runtime behavior.

⸻

🧪 Testing

* Tested locally
* Added/updated tests (not applicable for this minimal fix)
* Screenshots attached (not applicable)

Notes:

Running npm run lint still reports unrelated pre-existing TypeScript errors in:

* server.ts (multer module resolution)
* src/services/applicationService.ts (Type 'any' is not assignable to type 'never')

These issues are outside the scope of this pull request.

⸻

📸 Screenshots

Not applicable.

⸻

✅ Checklist

* My code follows the project’s coding standards.
* I have performed a self-review of my code.
* I have tested my changes before submitting.
* I have updated the documentation (if required).
* I have added or updated tests (not required for this fix).
* No unnecessary files or debug code are included.
* This pull request is ready for review.