### PR TITLE
feat: send admin email alerts for failed scraper jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "test-auth": "tsx tests/test-jit-auth.ts",
     "test-socket": "tsx tests/test-socket-fallback.ts",
     "test-eventbus": "tsx tests/test-eventbus.ts",
-    "test-admin-alerts": "tsx tests/test-admin-alerts.ts"
-    "test-eventbus": "tsx tests/test-eventbus.ts"
+    "test-admin-alerts": "tsx tests/test-admin-alerts.ts",
     "test-cache-keys": "tsx tests/test-cache-keys.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "test-scraper": "tsx tests/test-scraper.ts",
     "test-semantic-search": "tsx tests/test-semantic-search.ts",
     "test-auth": "tsx tests/test-jit-auth.ts",
-    "test-socket": "tsx tests/test-socket-fallback.ts"
+    "test-socket": "tsx tests/test-socket-fallback.ts",
+    "test-eventbus": "tsx tests/test-eventbus.ts",
+    "test-admin-alerts": "tsx tests/test-admin-alerts.ts"
   },
   "dependencies": {
     "@bull-board/api": "^8.1.2",

--- a/src/services/adminAlertService.ts
+++ b/src/services/adminAlertService.ts
@@ -1,0 +1,65 @@
+import { enqueueEmail } from "../queues/emailQueue.js";
+import { generateAdminAlertHtml } from "../workers/emailTemplates.js";
+
+/**
+ * Sends a critical alert to all configured system administrators.
+ * Used when background workers or queues experience permanent failures.
+ *
+ * @param workerName The name of the worker (e.g. 'ScraperWorker')
+ * @param job The BullMQ job object or any object containing job metadata
+ * @param customEnqueue Optional dependency injection for mocking email queue during tests
+ */
+export const sendAdminAlert = async (workerName: string, job: any, error: any, customEnqueue?: typeof enqueueEmail) => {
+  const _enqueue = customEnqueue || enqueueEmail;
+  try {
+    // 1. Get recipients: parse from config, supporting comma-separated multiple admins
+    const adminEmailsConfig = process.env.ADMIN_EMAILS || process.env.ADMIN_EMAIL || process.env.VITE_ADMIN_EMAILS || 'admin@yuvahub.com';
+    const adminEmails = adminEmailsConfig.split(',').map(email => email.trim()).filter(email => email.length > 0);
+
+    if (adminEmails.length === 0) {
+      console.warn(`[${workerName}] No admin emails configured to receive alerts.`);
+      return;
+    }
+
+    // 2. Extract job metadata safely
+    const jobId = job?.id || 'unknown';
+    const domain = job?.data?.domain || 'unknown';
+    const retryCount = job?.attemptsMade || 0;
+    const errorMessage = error?.message || String(error);
+
+    // 3. Generate structured HTML template
+    const htmlBody = generateAdminAlertHtml(workerName, jobId, domain, errorMessage, retryCount);
+    
+    // Fallback text body just in case email clients block HTML
+    const textBody = `🚨 [Alert] ${workerName} Job Failed!
+Job ID: ${jobId}
+Domain: ${domain}
+Reason: ${errorMessage}
+Retry Count: ${retryCount}
+Timestamp: ${new Date().toISOString()}`;
+
+    // 4. Enqueue email to all admins independently using Promise.allSettled
+    // This ensures that if one enqueue fails (e.g., malformed payload), others may still succeed.
+    const results = await Promise.allSettled(
+      adminEmails.map(email => 
+        _enqueue({
+          to: email,
+          subject: `🚨 [Alert] ${workerName} Permanently Failed: ${domain}`,
+          body: textBody,
+          html: htmlBody
+        })
+      )
+    );
+
+    // 5. Log outcome
+    const failedCount = results.filter(r => r.status === 'rejected').length;
+    if (failedCount > 0) {
+      console.error(`[${workerName}] Alert failed to enqueue for ${failedCount} admin(s).`);
+    } else {
+      console.log(`[${workerName}] Admin alert triggered for job ${jobId} to ${adminEmails.length} recipient(s).`);
+    }
+  } catch (err) {
+    // Top-level catch ensures this function NEVER crashes the calling worker
+    console.error(`[${workerName}] Critical failure in sendAdminAlert helper:`, err);
+  }
+};

--- a/src/workers/emailTemplates.ts
+++ b/src/workers/emailTemplates.ts
@@ -153,3 +153,46 @@ export function generateHackathonAlertHtml(title: string, organization: string, 
     </div>
   `;
 }
+
+export function generateAdminAlertHtml(workerName: string, jobId: string, domain: string, errorMessage: string, retryCount: number): string {
+  return `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; max-width: 600px; margin: auto; padding: 24px; border: 1px solid #ef4444; border-radius: 12px; background-color: #ffffff;">
+      <h2 style="color: #dc2626; margin: 0 0 6px 0; font-size: 20px; font-weight: 800;">🚨 Critical System Alert</h2>
+      <p style="color: #64748b; font-size: 14px; margin-top: 0;">A background worker job has exhausted all retries and failed permanently.</p>
+      <hr style="border: 0; border-top: 1px solid #f1f5f9; margin: 16px 0;" />
+      
+      <div style="background-color: #fef2f2; border: 1px solid #fecaca; border-radius: 8px; padding: 14px; margin-bottom: 20px;">
+        <h3 style="color: #991b1b; margin: 0 0 8px 0; font-size: 15px; font-weight: 700;">Worker: ${workerName}</h3>
+        <table style="width: 100%; font-size: 13px; color: #475569; border-collapse: collapse;">
+          <tr>
+            <td style="padding: 4px 0; font-weight: 600; width: 30%;">Job ID:</td>
+            <td style="padding: 4px 0;"><code>${jobId}</code></td>
+          </tr>
+          <tr>
+            <td style="padding: 4px 0; font-weight: 600;">Target Domain:</td>
+            <td style="padding: 4px 0;">${domain || "N/A"}</td>
+          </tr>
+          <tr>
+            <td style="padding: 4px 0; font-weight: 600;">Retry Attempts:</td>
+            <td style="padding: 4px 0;">${retryCount}</td>
+          </tr>
+          <tr>
+            <td style="padding: 4px 0; font-weight: 600;">Timestamp:</td>
+            <td style="padding: 4px 0;">${new Date().toISOString()}</td>
+          </tr>
+        </table>
+      </div>
+
+      <h4 style="color: #0f172a; margin: 0 0 8px 0; font-size: 14px; font-weight: 700;">Failure Reason</h4>
+      <p style="color: #b91c1c; line-height: 1.5; font-size: 13px; background-color: #fee2e2; padding: 12px; border-radius: 6px; font-family: monospace;">
+        ${errorMessage || "Unknown Error"}
+      </p>
+      
+      <div style="margin-top: 32px; padding-top: 20px; border-top: 1px solid #f1f5f9; text-align: center;">
+        <p style="color: #94a3b8; font-size: 11px; margin: 0;">
+          This is an automated administrative alert from YuvaHub.
+        </p>
+      </div>
+    </div>
+  `;
+}

--- a/src/workers/scraperWorker.ts
+++ b/src/workers/scraperWorker.ts
@@ -5,6 +5,8 @@ import dotenv from "dotenv";
 import crypto from "crypto";
 import { generateOpportunityEmbedding } from "../services/embedding.js";
 
+import { sendAdminAlert } from "../services/adminAlertService.js";
+
 dotenv.config();
 
 const uri = process.env.MONGODB_URI || "mongodb://localhost:27017";
@@ -88,7 +90,8 @@ scraperWorker.on("failed", (job, err) => {
   // Alerting mechanism: Check if this was the final attempt
   if (job && job.opts.attempts && job.attemptsMade === job.opts.attempts) {
     console.error(`[ALERT] Scraper Job ${job.id} for domain ${job.data.domain} failed ${job.attemptsMade} times in a row! Maintenance required.`);
-    // TODO: Publish to emailQueue to alert admin
+    
+    sendAdminAlert("ScraperWorker", job, err);
   }
 });
 

--- a/tests/test-admin-alerts.ts
+++ b/tests/test-admin-alerts.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert";
+import { sendAdminAlert } from "../src/services/adminAlertService.js";
+
+async function runTest() {
+  console.log("Starting test-admin-alerts.ts...");
+
+  // Setup environment for testing multiple admins
+  process.env.VITE_ADMIN_EMAILS = "maintainer1@yuvahub.com, maintainer2@yuvahub.com";
+  
+  const mockJob = {
+    id: "job_999",
+    data: { domain: "fail-domain.com" },
+    attemptsMade: 5
+  };
+  
+  const mockError = new Error("Simulated worker timeout");
+
+  let enqueuedEmails: any[] = [];
+  const mockEnqueueEmail = async (data: any) => {
+    enqueuedEmails.push(data);
+    return { id: "mock_email_" + Date.now() };
+  };
+
+  console.log("Triggering sendAdminAlert with mock enqueue...");
+  await sendAdminAlert("TestWorker", mockJob, mockError, mockEnqueueEmail as any);
+
+  try {
+    assert.strictEqual(enqueuedEmails.length, 2, "Should have enqueued exactly 2 emails for 2 admins");
+    
+    // Verify recipients
+    assert.strictEqual(enqueuedEmails[0].to, "maintainer1@yuvahub.com");
+    assert.strictEqual(enqueuedEmails[1].to, "maintainer2@yuvahub.com");
+    
+    // Verify text body
+    assert.ok(enqueuedEmails[0].body.includes("TestWorker Job Failed!"), "Text should contain worker name");
+    assert.ok(enqueuedEmails[0].body.includes("fail-domain.com"), "Text should contain domain");
+    assert.ok(enqueuedEmails[0].body.includes("Simulated worker timeout"), "Text should contain error message");
+
+    // Verify HTML body generated from emailTemplates.ts
+    assert.ok(enqueuedEmails[0].html.includes("job_999"), "HTML should contain job ID");
+    assert.ok(enqueuedEmails[0].html.includes("fail-domain.com"), "HTML should contain domain");
+    assert.ok(enqueuedEmails[0].html.includes("Simulated worker timeout"), "HTML should contain error message");
+    
+    console.log("✅ All regression tests passed successfully for sendAdminAlert.");
+  } catch (err) {
+    console.error("❌ Test assertion failed:", err);
+    process.exit(1);
+  }
+}
+
+runTest().catch(err => {
+  console.error("❌ Test script failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Description

This PR adds email alerts for scraper jobs that fail after all retry attempts.



Earlier, these failures were only logged, so it was easy to miss them. Now, when a scraper job fails after the last retry, an email is sent to the configured admin with the failure details.

---

## 🔗 Related Issue

- Closes #187

---

## What I changed

- Added email alerts for permanently failed scraper jobs.
- Reused the existing email queue instead of adding a new notification system.
- Included useful details like the job ID, target domain, retry count, failure reason, and timestamp in the email.
- Used the existing environment variables for admin email configuration.
- Added tests for the new alert flow.

---

## Why this helps

- Makes permanent scraper failures easier to notice.
- Gives admins enough information to investigate the issue quickly.
- Reuses the existing email flow, so no extra notification system is needed.
- Adds test coverage for the new behavior.

---

## Testing

- Ran the related tests locally.
- Verified that an email is queued after the final retry fails.
- Verified that the alert contains the expected job details.
- Existing TypeScript errors in the repository are unrelated to this change.