### PR TITLE
fix: generate unique offline cache keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test-semantic-search": "tsx tests/test-semantic-search.ts",
     "test-auth": "tsx tests/test-jit-auth.ts",
     "test-socket": "tsx tests/test-socket-fallback.ts",
-    "test-eventbus": "tsx tests/test-eventbus.ts"
+    "test-eventbus": "tsx tests/test-eventbus.ts",
+    "test-cache-keys": "tsx tests/test-cache-keys.ts"
   },
   "dependencies": {
     "@bull-board/api": "^8.1.2",

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -6,6 +6,7 @@
 import { auth } from '../lib/firebase';
 import * as geminiService from './gemini';
 import { getFilteredFallbacks } from './staticFallbacks';
+import { generateCacheKey } from '../utils/cacheUtils.js';
 
 const API_BASE_URL = "/api/v1";
 
@@ -152,7 +153,7 @@ export async function fetchLatestFeed() {
 }
 
 export async function fetchSmartFeed(profile: any, cursor?: string) {
-  const cacheKey = "smart_feed";
+  const cacheKey = generateCacheKey('smart_feed', { ...profile, cursor });
   try {
     const searchParams = new URLSearchParams();
     if (cursor) searchParams.append('cursor', cursor);
@@ -296,7 +297,7 @@ export async function chatWithAIMentorBackend(messages: any[], newMessage: strin
 }
 
 export async function fetchExploreFeed(cursor?: string, limit: number = 20) {
-  const cacheKey = "explore_feed";
+  const cacheKey = generateCacheKey('explore_feed', { cursor, limit });
   try {
     const searchParams = new URLSearchParams();
     if (cursor) searchParams.append('cursor', cursor);
@@ -377,7 +378,7 @@ export async function searchOpportunities(
   }, 
   cursor?: string
 ) {
-  const cacheKey = `search_${query.toLowerCase().replace(/\s+/g, '_')}_${JSON.stringify(filters || {})}`;
+  const cacheKey = generateCacheKey('search', { query: query.toLowerCase().trim(), ...filters, cursor });
   try {
     const searchParams = new URLSearchParams();
     searchParams.append('q', query);

--- a/src/utils/cacheUtils.ts
+++ b/src/utils/cacheUtils.ts
@@ -1,0 +1,14 @@
+/**
+ * Generates a uniquely deterministic cache key by sorting parameters.
+ * Fix for Issue #188: Prevents stale collisions and parameter-order duplicates.
+ */
+export function generateCacheKey(pathname: string, params: Record<string, any> = {}, method: string = "GET"): string {
+  const sortedKeys = Object.keys(params).sort();
+  const normalizedParams: Record<string, any> = {};
+  for (const k of sortedKeys) {
+    if (params[k] !== undefined && params[k] !== null && params[k] !== "") {
+      normalizedParams[k] = params[k];
+    }
+  }
+  return `${method}_${pathname}_${JSON.stringify(normalizedParams)}`;
+}

--- a/tests/test-cache-keys.ts
+++ b/tests/test-cache-keys.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert";
+import { generateCacheKey } from "../src/utils/cacheUtils.js";
+
+async function runTests() {
+  console.log("Starting Cache Key Regression Tests...");
+
+  // Test 1: Same endpoint + same params = identical keys
+  const key1 = generateCacheKey("smart_feed", { domain: "engineering", skills: ["node", "ts"] });
+  const key2 = generateCacheKey("smart_feed", { domain: "engineering", skills: ["node", "ts"] });
+  assert.strictEqual(key1, key2, "Identical inputs must produce identical cache keys");
+
+  // Test 2: Same endpoint + different params = different keys
+  const key3 = generateCacheKey("smart_feed", { domain: "design", skills: ["figma"] });
+  assert.notStrictEqual(key1, key3, "Different inputs must produce different cache keys");
+
+  // Test 3: Different parameter insertion order = identical keys (CRITICAL FOR BUG #188)
+  const key4a = generateCacheKey("search", { query: "job", limit: 10, cursor: "abc" });
+  const key4b = generateCacheKey("search", { cursor: "abc", query: "job", limit: 10 });
+  assert.strictEqual(key4a, key4b, "Object property insertion order must not change the cache key");
+
+  // Test 4: Different HTTP methods = different keys
+  const key5a = generateCacheKey("user", { id: 1 }, "GET");
+  const key5b = generateCacheKey("user", { id: 1 }, "POST");
+  assert.notStrictEqual(key5a, key5b, "Different HTTP methods must produce different cache keys");
+
+  // Test 5: Ignored undefined/null values
+  const key6a = generateCacheKey("explore", { limit: 20 });
+  const key6b = generateCacheKey("explore", { limit: 20, cursor: undefined, filter: null, query: "" });
+  assert.strictEqual(key6a, key6b, "Undefined, null, and empty string parameters should be ignored");
+
+  console.log("✅ All Cache Key regression tests passed successfully.");
+}
+
+runTests().catch(err => {
+  console.error("❌ Test failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Description

While checking the offline cache, I noticed that different requests can end up using the same cache entry because the cache key isn't unique enough. This can cause old or unrelated data to be returned when the app is working offline.

For example, if two requests have different query parameters, they may still reuse the same cached response.

---

## 🔗 Related Issue

- Closes #188 

---

## What I changed

- Added a reusable `generateCacheKey` helper to create unique cache keys.
- Updated the offline cache to generate keys using the request path and request parameters instead of shared static keys.
- Normalized query parameters so the order of parameters doesn't create different cache entries.
- Added regression tests to make sure cache keys stay consistent and collisions don't happen again.

---

## Why this helps

- Different requests now have their own cache entries.
- Cached data is less likely to become stale or mixed with another request.
- Cache behavior is more predictable during offline usage.
- The added tests help catch future regressions.

---

## Testing

- Ran `npm run test-cache-keys`.
- Verified the same request always generates the same cache key.
- Verified different requests generate different cache keys.
- Verified changing query parameter order doesn't change the generated cache key.