### PR TITLE
fix: remove hardcoded JWT secret fallback, add startup guard

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1654,7 +1654,10 @@ ${urls.join("\n")}
 
     // Try to verify as a standard JWT first (for our RBAC custom tokens)
     try {
-      const decoded = jwt.verify(idToken, process.env.JWT_SECRET || "yuvahub-secret-key") as any;
+      if (!process.env.JWT_SECRET) {
+        throw new Error("JWT_SECRET environment variable is required");
+      }
+      const decoded = jwt.verify(idToken, process.env.JWT_SECRET) as any;
       uid = decoded.sub || decoded.user_id || decoded.uid;
       email = decoded.email || "";
       role = decoded.role || "user";
@@ -4155,6 +4158,9 @@ ${JSON.stringify(userProfile, null, 2)}
 
 async function bootstrap() {
   try {
+    if (!process.env.JWT_SECRET) {
+      throw new Error("JWT_SECRET environment variable is required");
+    }
     await startServer(); // startServer initializes db and starts express
     
     await eventBus.connect();


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Summary

<!-- Briefly describe the purpose of this pull request -->

---

## 🔗 Related Issue

<!-- Example: Closes #123 -->

issue : #201 

---

## ✨ Changes Made

- Removed hardcoded "yuvahub-secret-key" fallback from jwt.verify() call at server.ts:1657
- Added guard to throw clear error if JWT_SECRET env var is missing
- Added startup check in bootstrap() so server fails fast at initialization when JWT_SECRET is not configured

---

## 🧪 Testing

- [ ] Tested locally
- [ ] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)

---

## 📸 Screenshots

<!-- Add screenshots or screen recordings here if applicable -->

---

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [ ] I have updated the documentation (if required).
- [ ] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

❤️ Thank you for contributing!