### PR TITLE
feat: add composite indexes for event filtering and sorting

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,33 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "events",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "category",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "date",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "opportunities",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "category",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "date",
+          "order": "ASCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
# Pull Request

## Description

This PR introduces the `firestore.indexes.json` configuration file to support complex queries in Firebase. Specifically, it adds the requested composite index for the `events` (and `opportunities`) collections, allowing filtering by `category` and sorting by `date` (both ascending). 

### Changes
- **Firestore Config**: Added `firestore.indexes.json` with the required composite index definitions to fix the "requires an index" error when querying events.

## Type of Change

- [x] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #192

## Testing

Verified the JSON structure locally for deployment to Firebase.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A - Backend changes only

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
