### PR TITLE
fix(opportunities): correctly fetch details for fallback opportunities (fixes #110)

### DIFF
--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -5,7 +5,7 @@
 
 import { auth } from '../lib/firebase';
 import * as geminiService from './gemini';
-import { getFilteredFallbacks } from './staticFallbacks';
+import { getFilteredFallbacks, CURATED_FALLBACKS } from './staticFallbacks';
 import { generateCacheKey } from '../utils/cacheUtils.js';
 
 const API_BASE_URL = "/api/v1";
@@ -554,6 +554,11 @@ export async function trackInteraction(opportunityId: string, actionType: 'view'
 }
 
 export async function fetchOpportunityById(id: string) {
+  if (id.startsWith("fb_")) {
+    const fallback = CURATED_FALLBACKS.find(fb => fb.id === id);
+    if (fallback) return fallback;
+  }
+
   try {
     const url = `${API_BASE_URL}/opportunity/${id}`;
     const response = await fetchWithRetry(url, {


### PR DESCRIPTION
# dYs? Pull Request

## dY"? Summary

Fixes the "Opportunity unavailable" error when users try to view the details of a fallback opportunity.

---

## dY"- Related Issue

Fixes #110

issue : #110

---

## o" Changes Made

- **`src/services/apiClient.ts`**: Updated `fetchOpportunityById` to intercept IDs starting with `fb_` and resolve them directly against the `CURATED_FALLBACKS` dataset rather than querying the backend. This prevents the backend from legitimately returning a 404 (not found) for mock data.

---

## dY  Testing

- [x] Tested locally
- [ ] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)

---

## dY", Screenshots

<!-- Add screenshots or screen recordings here if applicable -->

---

## o. Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [ ] I have updated the documentation (if required).
- [ ] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

? ,? Thank you for contributing!
