### PR TITLE
feat(scrapers): add luma and gsoc mock opportunities to scraper registry (fixes #138)

### DIFF
--- a/scrape-cli.ts
+++ b/scrape-cli.ts
@@ -85,6 +85,28 @@ async function runVerification() {
           opportunity_type: "hackathon",
           description: "Build next-gen AI apps using Google Cloud GenAI.",
           source_name: "Devfolio"
+      },
+      {
+          title: "AI Startup Founder Meetup",
+          organization: "Luma Events",
+          apply_link: "https://lu.ma/ai-startup-meetup",
+          tags: ["AI", "Startup", "Networking", "Meetup"],
+          deadline: "2026-08-20T18:00:00Z",
+          location: "San Francisco, CA",
+          opportunity_type: "event",
+          description: "Join top AI founders and investors for an evening of networking and panel discussions. Speakers include prominent VCs and successful founders.",
+          source_name: "Luma"
+      },
+      {
+          title: "Google Summer of Code (GSoC) 2026",
+          organization: "Google Open Source",
+          apply_link: "https://summerofcode.withgoogle.com/",
+          tags: ["Open Source", "Software Engineering", "Fellowship"],
+          deadline: "2026-04-02T18:00:00Z",
+          location: "Remote",
+          opportunity_type: "fellowship",
+          description: "A global, online program focused on bringing new contributors into open source software development.",
+          source_name: "GSoC"
       }
     ];
 


### PR DESCRIPTION
# dYs? Pull Request

## dY"? Summary

Adds mock data structures for Luma Events and Google Summer of Code (GSoC) to the centralized Node.js scraper registry, bridging the gap for the external scraper pipeline. 

---

## dY"- Related Issue

Fixes #138

issue : #138

---

## o" Changes Made

- **`scrape-cli.ts`**: Expanded the `mockOpportunities` array to include payload templates for Luma Events (AI Startup Founder Meetup) and GSoC (Fellowship). This ensures downstream events (like `OpportunityScrapedEvent`) generate standard payloads for these platforms.

---

## dY  Testing

- [x] Tested locally
- [ ] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)

---

## dY", Screenshots

<!-- Add screenshots or screen recordings here if applicable -->

---

## o. Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [ ] I have updated the documentation (if required).
- [ ] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

? ,? Thank you for contributing!
