### PR TITLE
fix: trigger auth flow from footer links

### DIFF
--- a/src/components/SplashAuth.tsx
+++ b/src/components/SplashAuth.tsx
@@ -368,20 +368,32 @@ export default function SplashAuth() {
                </p>
             </div>
             
-            <div className="flex flex-col gap-[9px]">
+            <div className="flex flex-col gap-[9px] items-start">
                <h4 className="font-bold text-text-primary mb-2">Competitions</h4>
-               <a href="#" className="text-[13px] text-text-secondary hover:text-primary-blue transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring rounded">Hackathons</a>
-               <a href="#" className="text-[13px] text-text-secondary hover:text-primary-blue transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring rounded">Quizzes</a>
-               <a href="#" className="text-[13px] text-text-secondary hover:text-primary-blue transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring rounded">Hiring Challenges</a>
-               <a href="#" className="text-[13px] text-text-secondary hover:text-primary-blue transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring rounded">Case Studies</a>
+               {['Hackathons', 'Quizzes', 'Hiring Challenges', 'Case Studies'].map((item) => (
+                  <button
+                     key={item}
+                     type="button"
+                     onClick={handleLogin}
+                     className="text-[13px] text-text-secondary hover:text-primary-blue transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring rounded text-left bg-transparent border-none p-0 cursor-pointer"
+                  >
+                     {item}
+                  </button>
+               ))}
             </div>
 
-            <div className="flex flex-col gap-[9px]">
+            <div className="flex flex-col gap-[9px] items-start">
                <h4 className="font-bold text-text-primary mb-2">Opportunities</h4>
-               <a href="#" className="text-[13px] text-text-secondary hover:text-primary-blue transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring rounded">Internships</a>
-               <a href="#" className="text-[13px] text-text-secondary hover:text-primary-blue transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring rounded">Full Time Jobs</a>
-               <a href="#" className="text-[13px] text-text-secondary hover:text-primary-blue transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring rounded">Scholarships</a>
-               <a href="#" className="text-[13px] text-text-secondary hover:text-primary-blue transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring rounded">Fellowships</a>
+               {['Internships', 'Full Time Jobs', 'Scholarships', 'Fellowships'].map((item) => (
+                  <button
+                     key={item}
+                     type="button"
+                     onClick={handleLogin}
+                     className="text-[13px] text-text-secondary hover:text-primary-blue transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring rounded text-left bg-transparent border-none p-0 cursor-pointer"
+                  >
+                     {item}
+                  </button>
+               ))}
             </div>
 
             <div>


### PR DESCRIPTION
# 🚀 Pull Request

- ## 📝 Summary

This PR fixes the footer links in `SplashAuth` that were using placeholder `href="#"` anchors. Clicking these links previously caused the page to jump to the top without performing any useful action.

The footer items now trigger the existing login flow by reusing the component's `handleLogin()` function, providing a smoother and more consistent user experience.

---

## 🔗 Related Issue

- Closes #186

---

## ✨ Changes Made

- Replaced placeholder footer anchor links with semantic button elements.
- Reused the existing `handleLogin()` function for all footer actions.
- Prevented the unwanted page scroll caused by `href="#"` while keeping the existing UI and styling unchanged.

---

## 🧪 Testing

- [x] Tested locally
- [ ] Added/updated tests (not required for this UI change)
- [ ] Screenshots attached (not applicable)

**Verification**
- Confirmed that clicking any footer item opens the authentication flow.
- Confirmed that the page no longer scrolls to the top.
- `npm run build` completed successfully.
- `npm run lint` reports existing TypeScript errors in `src/services/applicationService.ts`, which are unrelated to this change.

---

## 📸 Screenshots

Not applicable.

---

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [x] I have updated the documentation (if required).
- [x] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

❤️ Thank you for reviewing my contribution!