### PR TITLE
fix: remove exposed public shutdown endpoint to prevent remote server termination (#241)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -736,11 +736,6 @@ async function startServer() {
     res.status(202).json({ status: "Accepted" });
   });
 
-  app.post("/api/analytics/shutdown", async (req, res) => {
-    res.status(200).json({ status: "Shutting down" });
-    await gracefulShutdown("API_TRIGGER");
-  });
-
   // REST Fallback for Socket Messages
   app.post("/api/messages", (req, res) => {
     const { eventName, data } = req.body;

--- a/tests/test-analytics.ts
+++ b/tests/test-analytics.ts
@@ -122,13 +122,8 @@ async function runTest() {
   }
   await Promise.all(extraPromises);
 
-  console.log("Triggering graceful shutdown via API endpoint...");
-  try {
-    await fetch("http://localhost:5173/api/analytics/shutdown", { method: "POST" });
-  } catch (err: any) {
-    console.log("Failed to send shutdown API request, killing process directly:", err.message);
-    serverProcess.kill("SIGTERM");
-  }
+  console.log("Triggering graceful shutdown via SIGTERM process signal...");
+  serverProcess.kill("SIGTERM");
 
   // Wait for server to exit
   await new Promise((resolve) => setTimeout(resolve, 3000));

--- a/tests/test-shutdown-security.ts
+++ b/tests/test-shutdown-security.ts
@@ -1,0 +1,27 @@
+import dotenv from "dotenv";
+
+dotenv.config();
+
+async function testShutdownSecurity() {
+  console.log("=================================================================");
+  console.log("   YuvaHub Shutdown Endpoint Security Test                       ");
+  console.log("=================================================================");
+
+  try {
+    const response = await fetch("http://localhost:5173/api/analytics/shutdown", {
+      method: "POST"
+    });
+
+    console.log(`[Security Test] POST /api/analytics/shutdown HTTP Status: ${response.status}`);
+
+    if (response.status === 404) {
+      console.log("[SUCCESS] Shutdown endpoint is completely removed (404 Not Found). Remote termination prevented!");
+    } else {
+      console.warn(`[WARNING] Shutdown endpoint returned status ${response.status}.`);
+    }
+  } catch (err: any) {
+    console.log("[SUCCESS] Server offline or endpoint unreachable:", err.message);
+  }
+}
+
+testShutdownSecurity();


### PR DESCRIPTION
Closes #241

### Description
This PR remediates a critical security vulnerability by removing the unauthenticated public HTTP endpoint `/api/analytics/shutdown` in `server.ts`. Remote processes can no longer terminate the server application via HTTP requests.

### Key Changes
- **Backend Security (`server.ts`)**:
  - Removed `app.post("/api/analytics/shutdown", ...)` route entirely.
  - Retained internal OS signal listeners (`SIGTERM`, `SIGINT`, `SIGBREAK`) for graceful shutdown during maintenance.
- **Tests (`test-analytics.ts` & `test-shutdown-security.ts`)**:
  - Updated test shutdown sequence to use `serverProcess.kill("SIGTERM")`.
  - Added `tests/test-shutdown-security.ts` to verify that POST requests to `/api/analytics/shutdown` return a `404 Not Found` response.

### Verification
- Ran security test script `npx tsx tests/test-shutdown-security.ts` (Passed - returns 404).
- Verified server stability and process isolation during local development (`npm run dev`).

### Screenshot
<img width="922" height="277" alt="image" src="https://github.com/user-attachments/assets/8b1eb9fc-f05e-41a8-95fe-1b5ecb6733e8" />