### PR TITLE
Optimize Deadline Scheduler Database Queries

### DIFF
--- a/src/services/deadlineScheduler.ts
+++ b/src/services/deadlineScheduler.ts
@@ -1,3 +1,4 @@
+import { ObjectId } from "mongodb";
 import { enqueueEmail } from "../queues/emailQueue";
 import { enqueuePushNotification } from "../queues/pushQueue";
 import { Notification } from "../models/notificationSchema";
@@ -17,14 +18,87 @@ export async function runDeadlineChecks(db: any): Promise<void> {
     const oppsCollection = db.collection("opportunities");
     const notifCollection = db.collection("notifications");
 
-    // Fetch all users who have bookmarks and have deadline reminders enabled
+    // Fetch all users who have bookmarks
     const users = await usersCollection.find({
       bookmarks: { $exists: true, $not: { $size: 0 } }
     }).toArray();
 
     const now = new Date();
 
-    for (const user of users) {
+    // Filter users who have deadline reminders enabled
+    const activeUsers = users.filter(user => {
+      const prefs = user.notificationPreferences || { deadlineRemindersEnabled: true };
+      return prefs.deadlineRemindersEnabled !== false;
+    });
+
+    if (activeUsers.length === 0) {
+      return;
+    }
+
+    // Batch step 1: Collect unique opportunity IDs and active user UIDs
+    const uniqueOppIds = new Set<string>();
+    const activeUserUids: string[] = [];
+
+    for (const user of activeUsers) {
+      if (user.uid) activeUserUids.push(user.uid);
+      const bookmarks = user.bookmarks || [];
+      for (const oppId of bookmarks) {
+        if (oppId) uniqueOppIds.add(String(oppId));
+      }
+    }
+
+    // Batch step 2: Bulk fetch all required opportunities in 1 MongoDB query
+    const oppMap = new Map<string, any>();
+    if (uniqueOppIds.size > 0) {
+      const stringIds: string[] = [];
+      const objectIds: ObjectId[] = [];
+
+      for (const idStr of uniqueOppIds) {
+        stringIds.push(idStr);
+        if (ObjectId.isValid(idStr)) {
+          try {
+            objectIds.push(new ObjectId(idStr));
+          } catch {
+            // fallback if ObjectId instantiation fails
+          }
+        }
+      }
+
+      const queryConditions: any[] = [{ id: { $in: stringIds } }];
+      if (objectIds.length > 0) {
+        queryConditions.push({ _id: { $in: objectIds } });
+      }
+
+      const opportunities = await oppsCollection.find({
+        $or: queryConditions
+      }).toArray();
+
+      for (const opp of opportunities) {
+        if (opp._id) {
+          oppMap.set(opp._id.toString(), opp);
+        }
+        if (opp.id) {
+          oppMap.set(String(opp.id), opp);
+        }
+      }
+    }
+
+    // Batch step 3: Bulk fetch existing deadline_reminder notifications for active users in 1 MongoDB query
+    const notifiedSet = new Set<string>();
+    if (activeUserUids.length > 0) {
+      const existingNotifs = await notifCollection.find({
+        userId: { $in: activeUserUids },
+        type: "deadline_reminder"
+      }).toArray();
+
+      for (const notif of existingNotifs) {
+        const key = `${notif.userId}:${notif.targetId}:${notif.title}`;
+        notifiedSet.add(key);
+      }
+    }
+
+    // Process each user and bookmark using O(1) in-memory Map & Set lookups
+    for (const user of activeUsers) {
       const prefs = user.notificationPreferences || {
         emailEnabled: true,
         pushEnabled: true,
@@ -35,28 +109,11 @@ export async function runDeadlineChecks(db: any): Promise<void> {
         opportunityAlertsEnabled: true
       };
 
-      if (!prefs.deadlineRemindersEnabled) {
-        continue;
-      }
-
       const bookmarks = user.bookmarks || [];
-      
-      for (const oppId of bookmarks) {
-        let queryId;
-        try {
-          // MongoDB uses ObjectId for _id, but check fallback if it fails
-          const { ObjectId } = await import("mongodb");
-          queryId = new ObjectId(oppId);
-        } catch {
-          queryId = oppId;
-        }
 
-        const opportunity = await oppsCollection.findOne({
-          $or: [
-            { _id: queryId },
-            { id: oppId }
-          ]
-        });
+      for (const oppId of bookmarks) {
+        const oppIdStr = String(oppId);
+        const opportunity = oppMap.get(oppIdStr);
 
         if (!opportunity) {
           continue;
@@ -95,15 +152,9 @@ export async function runDeadlineChecks(db: any): Promise<void> {
           message = `Urgent Reminder: Today is the last day to apply for bookmarked opportunity "${opportunity.title}".`;
         }
 
-        // Check if user was already notified for this exact deadline condition (avoid duplicate alerts)
-        const existing = await notifCollection.findOne({
-          userId: user.uid,
-          targetId: oppId,
-          type: "deadline_reminder",
-          title
-        });
-
-        if (existing) {
+        // Check if user was already notified for this exact deadline condition
+        const notifKey = `${user.uid}:${oppId}:${title}`;
+        if (notifiedSet.has(notifKey)) {
           continue;
         }
 
@@ -119,6 +170,7 @@ export async function runDeadlineChecks(db: any): Promise<void> {
         };
 
         await notifCollection.insertOne(notificationDoc);
+        notifiedSet.add(notifKey);
         console.log(`[DeadlineScheduler] Reminded user ${user.uid} of deadline for opportunity ${oppId} (${diffDays} days left)`);
 
         // Real-Time Socket.io push (foreground handling)
@@ -181,27 +233,65 @@ export async function runWeeklyDigest(db: any): Promise<void> {
     const now = new Date();
     const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
 
-    for (const user of users) {
-      if (!user.email) continue;
-
+    const activeUsers = users.filter(user => {
+      if (!user.email) return false;
       const prefs = user.notificationPreferences || { emailEnabled: true };
-      if (prefs.emailEnabled === false) continue;
+      return prefs.emailEnabled !== false;
+    });
 
+    if (activeUsers.length === 0) return;
+
+    // Collect all unique oppIds
+    const uniqueOppIds = new Set<string>();
+    for (const user of activeUsers) {
+      const bookmarks = user.bookmarks || [];
+      for (const oppId of bookmarks) {
+        if (oppId) uniqueOppIds.add(String(oppId));
+      }
+    }
+
+    // Batch fetch opportunities
+    const oppMap = new Map<string, any>();
+    if (uniqueOppIds.size > 0) {
+      const stringIds: string[] = [];
+      const objectIds: ObjectId[] = [];
+
+      for (const idStr of uniqueOppIds) {
+        stringIds.push(idStr);
+        if (ObjectId.isValid(idStr)) {
+          try {
+            objectIds.push(new ObjectId(idStr));
+          } catch {
+            // fallback
+          }
+        }
+      }
+
+      const queryConditions: any[] = [{ id: { $in: stringIds } }];
+      if (objectIds.length > 0) {
+        queryConditions.push({ _id: { $in: objectIds } });
+      }
+
+      const opportunities = await oppsCollection.find({
+        $or: queryConditions
+      }).toArray();
+
+      for (const opp of opportunities) {
+        if (opp._id) {
+          oppMap.set(opp._id.toString(), opp);
+        }
+        if (opp.id) {
+          oppMap.set(String(opp.id), opp);
+        }
+      }
+    }
+
+    for (const user of activeUsers) {
       const bookmarks = user.bookmarks || [];
       const expiringOpps: Array<{ title: string; org: string; deadline: string }> = [];
 
       for (const oppId of bookmarks) {
-        let queryId;
-        try {
-          const { ObjectId } = await import("mongodb");
-          queryId = new ObjectId(oppId);
-        } catch {
-          queryId = oppId;
-        }
-
-        const opp = await oppsCollection.findOne({
-          $or: [{ _id: queryId }, { id: oppId }]
-        });
+        const opp = oppMap.get(String(oppId));
 
         if (!opp || !opp.deadline) continue;
         const deadline = new Date(opp.deadline);

--- a/tests/test-notifications.ts
+++ b/tests/test-notifications.ts
@@ -47,6 +47,21 @@ async function testNotifications() {
         }
         if (name === "opportunities") {
           return {
+            find: (q?: any) => ({
+              toArray: async () => {
+                if (!q) return mockOpps;
+                if (q.$or) {
+                  return mockOpps.filter(item => {
+                    return q.$or.some((cond: any) => {
+                      if (cond.id && cond.id.$in) return cond.id.$in.includes(item.id) || cond.id.$in.includes(String(item.id));
+                      if (cond._id && cond._id.$in) return cond._id.$in.some((id: any) => String(id) === String(item._id));
+                      return false;
+                    });
+                  });
+                }
+                return mockOpps;
+              }
+            }),
             findOne: async (q: any) => {
               return mockOpps.find(item => item.id === q.id || item._id === q._id || (q.$or && q.$or.some((o: any) => o._id === item._id || o.id === item.id)));
             },
@@ -66,6 +81,9 @@ async function testNotifications() {
             find: (q?: any) => ({
               toArray: async () => {
                 if (!q || !q.userId) return mockNotifs;
+                if (q.userId.$in) {
+                  return mockNotifs.filter(n => q.userId.$in.includes(n.userId) && (!q.type || n.type === q.type));
+                }
                 return mockNotifs.filter(n => n.userId === q.userId && (!q.type || n.type === q.type));
               }
             }),


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Summary

Optimized the deadline scheduler by eliminating the N+1 query pattern using batch MongoDB `$in` queries and in-memory lookups. This significantly reduces database load while preserving the existing notification and digest functionality.

---

## 🔗 Related Issue

Closes #248 

---

## ✨ Changes Made

* Replaced repeated per-bookmark opportunity lookups with a single batched MongoDB `$in` query and cached results using an in-memory `Map` for O(1) lookups.
* Optimized notification deduplication by batch-fetching existing deadline reminders and using a `Set` for constant-time duplicate checks.
* Removed redundant dynamic MongoDB imports and cleaned up the scheduler implementation without changing business logic.

---

## 🧪 Testing

* [x] Tested locally
* [ ] Added/updated tests (if applicable)
* [ ] Screenshots attached (if applicable)

**Verification performed:**

* Confirmed `runDeadlineChecks` now performs only **3 database read queries** regardless of the number of users/bookmarks.
* Confirmed `runWeeklyDigest` now performs only **2 database read queries**.
* Verified that deadline reminders and weekly digest notifications continue to function correctly after the optimization.

---

## 📸 Screenshots

Not applicable.

---

## ✅ Checklist

* [x] My code follows the project's coding standards.
* [x] I have performed a self-review of my code.
* [x] I have tested my changes before submitting.
* [ ] I have updated the documentation (if required).
* [ ] I have added or updated tests (if required).
* [x] No unnecessary files or debug code are included.
* [x] This pull request is ready for review.

---

❤️ Thank you for contributing!
