### PR TITLE
fix: enforce user profile validation for restricted fields

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -12,7 +12,9 @@ service cloud.firestore {
 
     match /users/{userId} {
       allow read: if isAuthenticated();
-      allow write: if isOwner(userId);
+      allow create: if isOwner(userId) && (!request.resource.data.keys().hasAny(['isAdmin', 'isVerified']) || (request.resource.data.get('isAdmin', false) == false && request.resource.data.get('isVerified', false) == false));
+      allow update: if isOwner(userId) && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['isAdmin', 'isVerified']);
+      allow delete: if isOwner(userId);
     }
 
     match /opportunities/{oppId} {


### PR DESCRIPTION
Closes #193

# Pull Request

## Description

This PR fixes a critical security vulnerability where malicious users could bypass validation in Firestore to update restricted profile fields (e.g., `isAdmin`, `isVerified`). The Firestore rules for the `users` collection have been updated to explicitly deny updates containing these fields, preventing unauthorized privilege escalation.

### Changes
- **Firestore Rules**: Replaced the generic `allow write: if isOwner(userId);` with separated `create`, `update`, and `delete` rules for `/users/{userId}`.
- **Payload Validation**: Added `!request.resource.data.diff(resource.data).affectedKeys().hasAny(['isAdmin', 'isVerified'])` to `update`, and equivalent assertions to `create`, ensuring no unauthorized initialization or modification of these sensitive fields.

## Type of Change

- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #193

## Testing

Verified the new `firestore.rules` locally by attempting to update user fields. Fields not listed (like `displayName`) can still be updated properly, while updates attempting to set `isAdmin` correctly fail.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A - Backend changes only

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
