### PR TITLE
fix(profile): update avatar caching and firebase user object

### DIFF
--- a/src/components/Tabs/Profile.tsx
+++ b/src/components/Tabs/Profile.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { ShieldCheck, Calendar, ExternalLink, RefreshCw } from 'lucide-react';
 import { db } from '../../lib/firebase';
 import { doc, setDoc } from 'firebase/firestore';
+import { updateProfile } from 'firebase/auth';
 import { UserProfile } from '../../types';
 import { ErrorState } from '../ui/states';
 import { useAppContext } from '../../context/AppContext';
@@ -130,6 +131,17 @@ export default function Profile() {
         }
       }
 
+      // Cache buster ensures UI visually updates even if Cloudinary URL is same
+      const finalUrl = uploadData.secure_url + (uploadData.secure_url.includes('?') ? '&' : '?') + 't=' + Date.now();
+
+      if (type === 'avatar' && user) {
+        try {
+          await updateProfile(user, { photoURL: finalUrl });
+        } catch (e) {
+          console.warn("Failed to update Firebase Auth user profile", e);
+        }
+      }
+
       // Step 3: Save metadata to MongoDB
       const saveRes = await fetch('/api/storage/save', {
         method: 'POST',
@@ -139,7 +151,7 @@ export default function Profile() {
         },
         body: JSON.stringify({
           type,
-          url: uploadData.secure_url,
+          url: finalUrl,
           publicId: uploadData.public_id
         })
       });


### PR DESCRIPTION

## Description

This PR resolves [Issue #255](https://github.com/Jivan-Patel/YuvaHub/issues/255) where the user profile image does not update in the UI after a successful upload until the page is refreshed.

### Root Cause
1. **Browser Caching**: The uploaded image replaced the existing image on Cloudinary with the same `public_id`, resulting in the exact same `secure_url`. Because the URL string was identical, React did not trigger a DOM update for the `src` attribute of the image, and the browser continued displaying the cached image.
2. **Firebase Auth Context**: The Firebase Authentication `user` object was not being updated with the new `photoURL` upon successful upload, resulting in an inconsistent auth state.

### Changes Made
- **Cache Buster**: Appended a query parameter (`?t={timestamp}`) to the generated image URL returned from the backend in `src/components/Tabs/Profile.tsx`. This guarantees that the `avatarUrl` saved to MongoDB (and subsequently populated in the React state) is unique for each upload, forcing the browser to fetch the new image immediately.
- **Firebase Auth Update**: Added `updateProfile` from `firebase/auth` within `handleFileUpload` to ensure that the user's `photoURL` in the Firebase Authentication context stays in sync with the newly uploaded image.

## Verification
- Uploaded a new profile image on the Profile Settings page.
- Confirmed that the UI instantly displays the new image without requiring a manual page refresh.
- Verified that the Firebase Authentication `user` object is correctly updated with the new URL.

## Related Issues
Fixes #255
