### PR TITLE
# fix(security): remove hardcoded default Meilisearch master key (#245)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,8 @@ FRONTEND_URL=http://localhost:5173
 # -------------------------------------------------------------------------
 # Required for fast full-text search.
 MEILI_HOST="http://127.0.0.1:7700"
+MEILI_MASTER_KEY=your_secure_meili_master_key_here
+
 
 # -------------------------------------------------------------------------
 # Firebase Authentication Setup Note

--- a/src/services/searchSync.ts
+++ b/src/services/searchSync.ts
@@ -1,9 +1,25 @@
 import { Meilisearch } from 'meilisearch';
 import { Db, ChangeStreamInsertDocument, ChangeStreamUpdateDocument, ChangeStreamReplaceDocument, ChangeStreamDeleteDocument } from 'mongodb';
 
+// --- SEC-245 FIX: Remove hardcoded default master key & validate startup ---
+const host = process.env.MEILI_HOST || 'http://localhost:7700';
+const apiKey = process.env.MEILI_MASTER_KEY;
+
+if (!apiKey) {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(
+      'FATAL CONFIGURATION ERROR: MEILI_MASTER_KEY environment variable is missing in production.'
+    );
+  } else {
+    console.warn(
+      '⚠️ [SearchSync] WARNING: MEILI_MASTER_KEY is not defined. Meilisearch client initialized without an admin key (Development Mode).'
+    );
+  }
+}
+
 export const meiliClient = new Meilisearch({
-  host: process.env.MEILI_HOST || 'http://localhost:7700',
-  apiKey: process.env.MEILI_MASTER_KEY || 'yuvahub-dev-master-key'
+  host,
+  apiKey: apiKey || '',
 });
 
 export async function initializeSearchSync(db: Db) {


### PR DESCRIPTION
##  Description
Resolves **SEC: Default Meilisearch Master Key (#245)**. Previously, if `MEILI_MASTER_KEY` was absent from the environment, the application fell back to `"yuvahub-dev-master-key"`. This potentially exposed administrative search access if deployed without explicit configuration.

---

## 🔗 Related Issue
Closes #245

---

##  Changes Made
* **Removed Hardcoded Default:** Stripped the `"yuvahub-dev-master-key"` string fallback from `searchSync.ts`.
* **Production Startup Validation:** Added a check that throws a fatal error on app startup if `MEILI_MASTER_KEY` is not provided when `NODE_ENV === 'production'`.
* **Development Warning:** Emits a warning log in non-production environments when running without a master key.
* **Updated `.env.example`:** Documented `MEILI_MASTER_KEY` as a required environment variable.

---

##  Testing
- [x] Verified app startup in `production` mode without `MEILI_MASTER_KEY` throws a fatal error as expected.
- [x] Verified app startup with `MEILI_MASTER_KEY` set connects properly to Meilisearch.
- [x] Verified development mode emits non-blocking warning.

---

##  Checklist
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [x] I have updated the documentation (`.env.example`).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.
