### PR TITLE
fix: remove duplicate SEO route definitions, consolidate single /robots.txt and /sitemap.xml

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -8,7 +8,7 @@ import { Server as SocketIOServer } from "socket.io";
 import { setSocketIO } from "./src/api/socketInstance.js";
 import { setupSocketEvents } from "./src/socket/index.js";
 import { runDeadlineChecks, runWeeklyDigest } from "./src/services/deadlineScheduler.js";
-import { dbCommand } from "./src/api/db.js";
+import { dbCommand, dbQuery } from "./src/api/db.js";
 
 // Import Main API Router
 import apiRoutes from "./src/api/routes/index.js";
@@ -38,6 +38,114 @@ app.use(express.urlencoded({ limit: "50mb", extended: true }));
 
 // Setup API Routes
 app.use("/api", apiRoutes);
+
+// ── SEO Routes (root-level for crawler discovery) ──────────────────────
+
+app.get("/robots.txt", (req, res) => {
+  const baseUrl = process.env.APP_URL || "https://yuvahub.xyz";
+  const robotsTxt = [
+    "User-agent: *",
+    "Allow: /",
+    "Allow: /opportunities",
+    "Allow: /about",
+    "Allow: /privacy",
+    "Allow: /terms",
+    "Allow: /cookies",
+    "Allow: /guidelines",
+    "Allow: /security",
+    "Allow: /support",
+    "Allow: /legal",
+    "Allow: /opportunity/",
+    "Disallow: /admin/",
+    "Disallow: /dashboard/",
+    "Disallow: /bookmarks/",
+    "Disallow: /submit/",
+    "Disallow: /settings/",
+    "Disallow: /profile/",
+    "Disallow: /mentorship/",
+    "Disallow: /community/",
+    "Disallow: /ai_assistant/",
+    "Disallow: /api/",
+    "",
+    "Content-Signal: ai-train=no, search=yes, ai-input=no",
+    "",
+    `Sitemap: ${baseUrl}/sitemap.xml`,
+    "",
+  ].join("\n");
+  res.header("Content-Type", "text/plain");
+  res.send(robotsTxt);
+});
+
+app.get("/sitemap.xml", async (req, res) => {
+  try {
+    const baseUrl = process.env.APP_URL || "https://yuvahub.xyz";
+    const staticPaths = [
+      "",
+      "/opportunities",
+      "/about",
+      "/privacy",
+      "/terms",
+      "/cookies",
+      "/guidelines",
+      "/security",
+      "/support",
+      "/legal",
+    ];
+
+    let urls = staticPaths.map((p) => {
+      return `  <url>
+    <loc>${baseUrl}${p}</loc>
+    <changefreq>daily</changefreq>
+    <priority>${p === "" ? "1.0" : "0.8"}</priority>
+  </url>`;
+    });
+
+    // Fetch opportunities if DB is ready
+    if (dbQuery) {
+      try {
+        const items = await dbQuery
+          .collection("opportunities")
+          .find({})
+          .project({ _id: 1, title: 1, created_at: 1 })
+          .toArray();
+
+        const oppUrls = items.map((item: any) => {
+          const id = item._id ? item._id.toString() : item.id;
+          const title = item.title || "opportunity";
+          const cleanTitle = title
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/^-+|-+$/g, "");
+          const lastmod = item.created_at
+            ? new Date(item.created_at).toISOString().split("T")[0]
+            : new Date().toISOString().split("T")[0];
+          return `  <url>
+    <loc>${baseUrl}/opportunity/${id}/${cleanTitle}</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>`;
+        });
+        urls = urls.concat(oppUrls);
+      } catch (dbErr) {
+        console.error("[Sitemap] Error fetching opportunities:", dbErr);
+      }
+    }
+
+    const sitemapXml = [
+      `<?xml version="1.0" encoding="UTF-8"?>`,
+      `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`,
+      ...urls,
+      `</urlset>`,
+    ].join("\n");
+
+    res.header("Content-Type", "application/xml");
+    res.send(sitemapXml);
+  } catch (err) {
+    console.error("[Sitemap] Generation error:", err);
+    res.status(500).send("Internal Server Error");
+  }
+});
 
 // Fallback Route
 app.use((req, res) => {


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Summary

Removes duplicate SEO route definitions and consolidates a single set of `/robots.txt` and `/sitemap.xml` handlers in `server.ts`. The old monolithic server defined these routes twice — the second copy was dead code that could never be reached. The upstream MVC refactor removed both copies entirely, causing a regression. This PR restores the single consolidated (more-complete) version.

---

## 🔗 Related Issue

Closes #261

---

## ✨ Changes Made

- **`server.ts`** — Added one consolidated set of root-level SEO routes:
  - `GET /robots.txt` with 16+ explicit Allow/Disallow rules, `Content-Signal: ai-train=no` header, and dynamic `Sitemap` URL via `APP_URL` environment variable
  - `GET /sitemap.xml` with 10 static page URLs (home, opportunities, about, privacy, terms, cookies, guidelines, security, support, legal) plus dynamic opportunity URLs fetched from MongoDB with SEO-friendly slugs, proper `lastmod`/`changefreq`/`priority`, and graceful fallback when DB is unavailable
  - Routes are registered before the 404 fallback to ensure crawler discovery

---

## 🧪 Testing

- [x] Tested locally
- [ ] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)

TypeScript type-check passes (pre-existing missing `@types/node` warnings unrelated). The change is a restoration of previously-working functionality with no breaking changes.

---

## 📸 Screenshots

N/A

---

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [ ] I have updated the documentation (if required).
- [ ] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

❤️ Thank you for contributing!
