### PR TITLE
[Feature]: Implement Resume PDF Export Generation

### DIFF
--- a/src/api/controllers/resumeController.ts
+++ b/src/api/controllers/resumeController.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { jsPDF } from "jspdf";
 import { dbCommand, dbQuery } from "../db.js";
 import { safeObjectId } from "../../lib/utils.js";
 
@@ -176,3 +177,106 @@ export const handleSetDefaultResume = async (req: any, res: any) => {
     res.status(500).json({ error: err.message || "Failed to set default resume" });
   }
 };
+
+export const handleExportResumeToPDF = async (req: any, res: any) => {
+  try {
+    const user = req.user;
+    if (!user || !user.uid) return res.status(401).json({ error: "Unauthorized" });
+    if (!dbQuery) return res.status(503).json({ error: "Database unavailable" });
+
+    const usersCol = dbQuery.collection("users");
+    const userProfile = await usersCol.findOne({ uid: user.uid });
+
+    if (!userProfile) {
+      return res.status(404).json({ error: "User profile not found" });
+    }
+
+    const doc = new jsPDF({
+      orientation: "portrait",
+      unit: "pt",
+      format: "letter"
+    });
+
+    const margin = 40;
+    let y = 60;
+    const pageWidth = doc.internal.pageSize.getWidth();
+    const pageHeight = doc.internal.pageSize.getHeight();
+
+    const writeText = (text: string, fontSize = 10, fontStyle = "normal", color = [0, 0, 0], indent = 0) => {
+      if (!text) return;
+      doc.setFont("helvetica", fontStyle as any);
+      doc.setFontSize(fontSize);
+      doc.setTextColor(color[0], color[1], color[2]);
+      
+      const lines = doc.splitTextToSize(String(text), pageWidth - (margin * 2) - indent);
+      
+      for (const line of lines) {
+        if (y + 16 > pageHeight - margin) {
+          doc.addPage();
+          y = 60;
+        }
+        doc.text(line, margin + indent, y);
+        y += 16;
+      }
+    };
+
+    // Name
+    const name = userProfile.name || "Unknown User";
+    writeText(name, 24, "bold", [17, 24, 39], 0);
+    y += 10;
+
+    // Contact Info (optional addition)
+    if (userProfile.email) {
+      writeText(userProfile.email, 10, "normal", [75, 85, 99], 0);
+      y += 20;
+    }
+
+    // Education
+    if (userProfile.education && Array.isArray(userProfile.education) && userProfile.education.length > 0) {
+      writeText("Education", 16, "bold", [31, 41, 55], 0);
+      y += 5;
+      for (const edu of userProfile.education) {
+        writeText(`${edu.degree || ""} - ${edu.institution || ""}`, 12, "bold", [0, 0, 0], 10);
+        writeText(`${edu.dates || ""}`, 10, "italic", [75, 85, 99], 10);
+        if (edu.gpa) {
+          writeText(`GPA: ${edu.gpa}`, 10, "normal", [55, 65, 81], 10);
+        }
+        y += 10;
+      }
+    }
+
+    // Experience
+    if (userProfile.workExperience && Array.isArray(userProfile.workExperience) && userProfile.workExperience.length > 0) {
+      writeText("Experience", 16, "bold", [31, 41, 55], 0);
+      y += 5;
+      for (const exp of userProfile.workExperience) {
+        writeText(`${exp.role || ""} at ${exp.company || ""}`, 12, "bold", [0, 0, 0], 10);
+        writeText(`${exp.dates || ""}`, 10, "italic", [75, 85, 99], 10);
+        if (exp.impact) {
+          writeText(exp.impact, 10, "normal", [55, 65, 81], 10);
+        }
+        y += 10;
+      }
+    }
+
+    // Skills
+    if (userProfile.skills && Array.isArray(userProfile.skills) && userProfile.skills.length > 0) {
+      writeText("Skills", 16, "bold", [31, 41, 55], 0);
+      y += 5;
+      const skillsText = userProfile.skills.join(", ");
+      writeText(skillsText, 10, "normal", [55, 65, 81], 10);
+      y += 10;
+    }
+
+    const pdfBuffer = Buffer.from(doc.output("arraybuffer"));
+    
+    res.setHeader("Content-Type", "application/pdf");
+    res.setHeader("Content-Disposition", `attachment; filename="${name.replace(/[^a-z0-9]/gi, '_').toLowerCase()}_resume.pdf"`);
+    res.status(200).send(pdfBuffer);
+    
+  } catch (err: any) {
+    console.error("[Resumes] Export to PDF error:", err);
+    res.status(500).json({ error: err.message || "Failed to export resume to PDF" });
+  }
+};
+

--- a/src/api/routes/resumeRoutes.ts
+++ b/src/api/routes/resumeRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { handleListResumes, handleCreateResume, handleRenameResume, handleDeleteResume, handleSetDefaultResume } from "../controllers/resumeController.js";
+import { handleListResumes, handleCreateResume, handleRenameResume, handleDeleteResume, handleSetDefaultResume, handleExportResumeToPDF } from "../controllers/resumeController.js";
 import { authMiddleware } from "../../middleware/auth.js";
 
 const router = Router();
@@ -9,5 +9,5 @@ router.post("/resumes", authMiddleware, handleCreateResume);
 router.put("/resumes/:id/rename", authMiddleware, handleRenameResume);
 router.delete("/resumes/:id", authMiddleware, handleDeleteResume);
 router.put("/resumes/:id/default", authMiddleware, handleSetDefaultResume);
-
+router.get("/resumes/:id/export/pdf", authMiddleware, handleExportResumeToPDF);
 export default router;

--- a/tests/test-resume-export.ts
+++ b/tests/test-resume-export.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleExportResumeToPDF } from '../src/api/controllers/resumeController.js';
+import * as dbModule from '../src/api/db.js';
+
+vi.mock('../src/api/db.js', () => ({
+  dbQuery: {
+    collection: vi.fn(),
+  },
+  dbCommand: {
+    collection: vi.fn(),
+  }
+}));
+
+describe('Resume PDF Export', () => {
+  let mockReq: any;
+  let mockRes: any;
+  let mockUsersCol: any;
+
+  beforeEach(() => {
+    mockReq = {
+      user: { uid: 'test-user-123' },
+      params: { id: 'dummy-resume-id' }
+    };
+    
+    mockRes = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+      setHeader: vi.fn(),
+      send: vi.fn()
+    };
+
+    mockUsersCol = {
+      findOne: vi.fn()
+    };
+
+    (dbModule.dbQuery as any).collection.mockReturnValue(mockUsersCol);
+  });
+
+  it('should return 401 if user is not authenticated', async () => {
+    mockReq.user = null;
+    await handleExportResumeToPDF(mockReq, mockRes);
+    expect(mockRes.status).toHaveBeenCalledWith(401);
+    expect(mockRes.json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+  });
+
+  it('should return 404 if user profile is not found', async () => {
+    mockUsersCol.findOne.mockResolvedValue(null);
+    await handleExportResumeToPDF(mockReq, mockRes);
+    expect(mockRes.status).toHaveBeenCalledWith(404);
+    expect(mockRes.json).toHaveBeenCalledWith({ error: 'User profile not found' });
+  });
+
+  it('should generate PDF and return as buffer stream', async () => {
+    mockUsersCol.findOne.mockResolvedValue({
+      uid: 'test-user-123',
+      name: 'John Doe',
+      email: 'john@example.com',
+      education: [
+        { degree: 'B.S. Computer Science', institution: 'State University', dates: '2016-2020', gpa: '3.8' }
+      ],
+      workExperience: [
+        { role: 'Software Engineer', company: 'Tech Corp', dates: '2020-Present', impact: 'Built cool stuff' }
+      ],
+      skills: ['TypeScript', 'React', 'Node.js']
+    });
+
+    await handleExportResumeToPDF(mockReq, mockRes);
+
+    expect(mockUsersCol.findOne).toHaveBeenCalledWith({ uid: 'test-user-123' });
+    expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', 'application/pdf');
+    expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Disposition', 'attachment; filename="john_doe_resume.pdf"');
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.send).toHaveBeenCalled();
+    
+    const sendArg = mockRes.send.mock.calls[0][0];
+    expect(Buffer.isBuffer(sendArg)).toBe(true);
+  });
+
+  it('should handle missing fields gracefully without crashing', async () => {
+    mockUsersCol.findOne.mockResolvedValue({
+      uid: 'test-user-123',
+      name: 'Jane Smith'
+      // Missing education, experience, skills, email
+    });
+
+    await handleExportResumeToPDF(mockReq, mockRes);
+
+    expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', 'application/pdf');
+    expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Disposition', 'attachment; filename="jane_smith_resume.pdf"');
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.send).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- closes #300

### Description

This PR introduces a new backend endpoint that allows users to export their profile information as a clean, standardized PDF document. Having a portable version of their profile is critical for external job applications and expanding the reach of the YuvaHub platform.

### Changes Made

- **New Route (`src/api/routes/resumeRoutes.ts`)**: 
  - Added `GET /api/resumes/:id/export/pdf`.
  - Protected by `authMiddleware`.
- **Export Handler (`src/api/controllers/resumeController.ts`)**: 
  - Implemented `handleExportResumeToPDF`.
  - Queries the `users` collection using the authenticated user's ID to fetch the `UserProfile`.
  - Uses the existing `jspdf` dependency to programmatically draw the user's profile info (Name, Email, Education, Experience, Skills) onto a standard Letter-sized PDF template.
  - Automatically handles missing data gracefully (e.g., skips the "Experience" section if the user has no listed experience).
  - Streams the generated PDF directly to the client with `Content-Type: application/pdf` and `Content-Disposition: attachment`.
- **Unit Tests (`tests/test-resume-export.ts`)**: 
  - Added a comprehensive `vitest` suite to verify authentication guards, 404 handling, successful PDF generation, and graceful handling of missing profile fields.

### How to Test

1. Start the server locally (`npm run dev:server`).
2. Ensure you have an authenticated user with some profile data populated.
3. Make an authenticated GET request to `/api/resumes/dummy-id/export/pdf`.
4. Verify that a `.pdf` file is downloaded and contains the correct formatted data.
5. Run the new test suite via `npx vitest run tests/test-resume-export.ts`.
