### PR TITLE
fix: resolve WebSocket 404 and health endpoint in production (#323)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -25,9 +25,11 @@ Sentry.init({
 const app = express();
 const server = http.createServer(app);
 
-const corsOrigins = process.env.NODE_ENV === "development" 
-  ? ["http://localhost:3000", "http://127.0.0.1:3000"]
-  : ["https://yuvahub.xyz", "https://www.yuvahub.xyz", "https://yuvahub-web.vercel.app"];
+const corsOrigins = process.env.FRONTEND_URL
+  ? [process.env.FRONTEND_URL]
+  : process.env.NODE_ENV === "development"
+    ? ["http://localhost:3000", "http://127.0.0.1:3000"]
+    : ["https://yuvahub.xyz", "https://www.yuvahub.xyz", "https://yuvahub-web.vercel.app"];
 
 // Initialize Socket.io Singleton
 const io = new SocketIOServer(server, { cors: { origin: corsOrigins, credentials: true } });

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { apiRouter } from "../../routes/index.js";
 import authRoutes from "./authRoutes.js";
 import userRoutes from "./userRoutes.js";
 import bookmarkRoutes from "./bookmarkRoutes.js";
@@ -24,6 +25,7 @@ const v1Router = Router();
 
 // Define all routers
 const routes = [
+  apiRouter,
   authRoutes,
   userRoutes,
   bookmarkRoutes,

--- a/src/context/SocketContext.tsx
+++ b/src/context/SocketContext.tsx
@@ -25,7 +25,8 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
   useEffect(() => {
     // Initialize socket with explicitly allowed transports for robust fallback
-    const socketInstance = io({
+    const serverUrl = import.meta.env.VITE_API_URL || "";
+    const socketInstance = io(serverUrl, {
       transports: ['websocket', 'polling'],
       reconnectionAttempts: 10,
       reconnectionDelay: 1000,


### PR DESCRIPTION
## 📝 Summary

Fixed WebSocket 404 handshake failure and health endpoint unreachable in production by correcting the Socket.IO client connection URL, mounting the orphaned health router, and making CORS origins configurable via environment variables.

---

## 🔗 Related Issue

issue : #323

---

## ✨ Changes Made

- **`src/api/routes/index.ts`**: Imported and mounted the health router (`apiRouter`) so `/api/v1/health` and `/api/health` return 200 instead of 404
- **`src/context/SocketContext.tsx`**: Added `import.meta.env.VITE_API_URL` as the Socket.IO server URL so the client connects to the Render backend in production instead of the Vercel frontend origin (which has no Socket.IO running)
- **`server.ts`**: Updated CORS origins to respect the `FRONTEND_URL` environment variable with a fallback to hardcoded values, fixing cross-origin rejection when the frontend URL changes

---

## 🧪 Testing

- [x] Tested locally
- [ ] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)

---

## 📸 Screenshots

N/A

---

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [ ] I have updated the documentation (if required).
- [ ] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.