### PR TITLE
[Feature]: Implement saved opportunities bookmarking and fix MockDB

### DIFF
--- a/src/api/controllers/opportunityController.ts
+++ b/src/api/controllers/opportunityController.ts
@@ -6,6 +6,44 @@ import { meiliClient } from "../../services/searchSync.js";
 import { generateOpportunityEmbedding } from "../../services/embedding.js";
 import { CURATED_FALLBACKS } from "../../services/staticFallbacks.js";
 
+// Toggle bookmark for an opportunity
+export const toggleBookmark = async (req: Request, res: Response) => {
+  try {
+    const user = req.user;
+    if (!dbCommand) return res.status(503).json({ error: "Database not available" });
+    
+    const opportunityId = req.params.id;
+    if (!opportunityId) return res.status(400).json({ error: "Missing opportunityId" });
+    
+    // Check if opportunity exists first
+    const oid = safeObjectId(opportunityId);
+    const query = oid ? { _id: oid } : { id: opportunityId };
+    const opp = await dbCommand.collection("opportunities").findOne(query);
+    if (!opp) return res.status(404).json({ error: "Opportunity not found" });
+    
+    const collection = dbCommand.collection("saved_opportunities");
+    const existing = await collection.findOne({ userId: user.uid, opportunityId });
+    
+    if (existing) {
+      // Un-bookmark
+      await collection.deleteOne({ userId: user.uid, opportunityId });
+      return res.json({ saved: false });
+    } else {
+      // Bookmark
+      await collection.insertOne({
+        userId: user.uid,
+        opportunityId,
+        createdAt: new Date()
+      });
+      return res.json({ saved: true });
+    }
+  } catch (err: any) {
+    console.error("POST /api/opportunities/:id/bookmark error:", err);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+};
+
+
 /**
  * Helper to escape user-controlled text strings for safe HTML / SEO metadata insertion
  */

--- a/src/api/controllers/userController.ts
+++ b/src/api/controllers/userController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
-import { dbCommand } from "../db.js";
+import { dbCommand, dbQuery } from "../db.js";
+import { safeObjectId } from "../../lib/utils.js";
 import { deleteFirebaseUser } from "../../middleware/auth.js";
 
 export const syncUser = (req: Request, res: Response) => {
@@ -26,5 +27,63 @@ export const deleteAccount = async (req: Request, res: Response) => {
   } catch (err: any) {
     console.error("[Auth] Error deleting user account:", err);
     res.status(500).json({ error: "Failed to delete account" });
+  }
+};
+
+export const getSavedOpportunities = async (req: Request, res: Response) => {
+  try {
+    const user = req.user;
+    if (!dbQuery) return res.status(503).json({ error: "Database not available" });
+
+    const limit = parseInt(req.query.limit as string) || 10;
+    const offset = parseInt(req.query.offset as string) || 0;
+
+    const savedOps = await dbQuery.collection("saved_opportunities")
+      .find({ userId: user.uid })
+      .sort({ createdAt: -1 })
+      .skip(offset)
+      .limit(limit)
+      .toArray();
+
+    if (savedOps.length === 0) {
+      return res.json({ items: [], total: 0 });
+    }
+
+    const opportunityIds = savedOps.map((s: any) => {
+      const oid = safeObjectId(s.opportunityId);
+      return oid ? oid : s.opportunityId;
+    });
+
+    const objectIds = opportunityIds.filter((id: any) => typeof id === 'object');
+    const stringIds = opportunityIds.filter((id: any) => typeof id === 'string');
+    
+    const queryConditions = [];
+    if (objectIds.length > 0) queryConditions.push({ _id: { $in: objectIds } });
+    if (stringIds.length > 0) queryConditions.push({ id: { $in: stringIds } });
+
+    let opportunities: any[] = [];
+    if (queryConditions.length > 0) {
+      opportunities = await dbQuery.collection("opportunities")
+        .find({ $or: queryConditions })
+        .toArray();
+    }
+      
+    const sortedOpportunities = savedOps.map((s: any) => {
+       const oid = safeObjectId(s.opportunityId);
+       return opportunities.find((o: any) => 
+         (o._id && oid && o._id.equals(oid)) || (o.id && o.id === s.opportunityId)
+       );
+    }).filter(Boolean).map((o: any) => {
+       const mapped = { ...o, id: o._id ? o._id.toString() : o.id };
+       delete mapped._id;
+       return mapped;
+    });
+    
+    const total = await dbQuery.collection("saved_opportunities").countDocuments({ userId: user.uid });
+
+    res.json({ items: sortedOpportunities, total });
+  } catch (err: any) {
+    console.error("GET /api/users/me/saved-opportunities error:", err);
+    res.status(500).json({ error: "Internal Server Error" });
   }
 };

--- a/src/api/db.ts
+++ b/src/api/db.ts
@@ -111,6 +111,12 @@ export class MemoryCollection {
               if (cond[k].$regex) {
                 const regex = new RegExp(cond[k].$regex, cond[k].$options || "");
                 if (regex.test(r[k])) return true;
+              } else if (cond[k].$in) {
+                if (cond[k].$in.some((val: any) => {
+                  if (typeof val === 'object' && val.equals) return val.equals(r[k]);
+                  if (typeof r[k] === 'object' && r[k].equals) return r[k].equals(val);
+                  return r[k] === val || r[k]?.toString() === val?.toString();
+                })) return true;
               } else {
                 if (r[k] === cond[k]) return true;
               }
@@ -126,10 +132,15 @@ export class MemoryCollection {
 
     const cursor = {
       sort: () => cursor,
+      skip: (n: number) => { result = result.slice(n); return cursor; },
       limit: (n: number) => { result = result.slice(0, n); return cursor; },
       toArray: async () => result
     };
     return cursor;
+  }
+  async countDocuments(query: any = {}) {
+    const res = await this.find(query).toArray();
+    return res.length;
   }
   async findOne(query: any) {
     const res = await this.find(query).toArray();
@@ -179,7 +190,6 @@ export class MemoryCollection {
     }
     return { deletedCount: this.data.length < initialLen ? 1 : 0 };
   }
-  async countDocuments() { return this.data.length; }
   async createIndex(keys: any, options: any) { return "mock_index"; }
   aggregate() { return { toArray: async () => [] }; }
   initializeUnorderedBulkOp() {
@@ -267,7 +277,7 @@ export async function initializeDatabase(): Promise<void> {
     } catch (err) {
       console.error("[Database] Connection failed, falling back to Mock Data:", err);
       dbCommand = new MockDB();
-      dbQuery = new MockDB();
+      dbQuery = dbCommand;
       setupDNL(dbCommand);
       initializeSearchSync(dbQuery).catch(err => console.error('[SearchSync] Non-fatal init error:', err));
       // Kick off the background reconnection loop so the system can
@@ -277,7 +287,7 @@ export async function initializeDatabase(): Promise<void> {
   } else {
     console.log("[Database] No MONGODB_URI provided. Running in Offline Mock mode.");
     dbCommand = new MockDB();
-    dbQuery = new MockDB();
+    dbQuery = dbCommand;
     setupDNL(dbCommand);
     initializeSearchSync(dbQuery).catch(err => console.error('[SearchSync] Non-fatal init error:', err));
   }

--- a/src/api/routes/opportunityRoutes.ts
+++ b/src/api/routes/opportunityRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { getOpportunities, getTrendingOpportunities, semanticSearch, getLatestOpportunities, submitOpportunity, getOpportunityById, updateOpportunity } from "../controllers/opportunityController.js";
+import { getOpportunities, getTrendingOpportunities, semanticSearch, getLatestOpportunities, submitOpportunity, getOpportunityById, updateOpportunity, toggleBookmark } from "../controllers/opportunityController.js";
 import { authMiddleware, adminOnly } from "../../middleware/auth.js";
 import { cacheMiddleware } from "../middlewares/cacheMiddleware.js";
 import { markdownNegotiation } from "../middlewares/markdownNegotiation.js";
@@ -13,5 +13,6 @@ router.get("/opportunities/latest", getLatestOpportunities);
 router.post("/opportunities", authMiddleware, submitOpportunity);
 router.get("/opportunity/:id", cacheMiddleware(3600, (req: any) => `opportunity:${req.params.id}`), markdownNegotiation, getOpportunityById);
 router.put("/opportunity/:id", authMiddleware, adminOnly, updateOpportunity);
+router.post("/opportunities/:id/bookmark", authMiddleware, toggleBookmark);
 
 export default router;

--- a/src/api/routes/userRoutes.ts
+++ b/src/api/routes/userRoutes.ts
@@ -1,9 +1,10 @@
 import { Router } from "express";
-import { syncUser, deleteAccount } from "../controllers/userController.js";
+import { syncUser, deleteAccount, getSavedOpportunities } from "../controllers/userController.js";
 import { authMiddleware } from "../../middleware/auth.js";
 
 const router = Router();
 
+router.get("/users/me/saved-opportunities", authMiddleware, getSavedOpportunities);
 router.get("/user/sync", authMiddleware, syncUser);
 router.delete("/user", authMiddleware, deleteAccount);
 

--- a/tests/test-saved-opportunities.ts
+++ b/tests/test-saved-opportunities.ts
@@ -1,0 +1,140 @@
+import dotenv from 'dotenv';
+dotenv.config();
+import { spawn } from 'child_process';
+import fetch from 'node-fetch';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+const PORT = Math.floor(Math.random() * 10000) + 10000;
+
+describe('test-saved-opportunities.ts', () => {
+  it('should toggle bookmarks and retrieve saved opportunities', async () => {
+    try {
+      console.log('=====================================================');
+      console.log('      Saved Opportunities Integration Test           ');
+      console.log('=====================================================');
+
+      console.log(`[Test] Starting server.ts on port ${PORT} in Mock mode...`);
+      const serverProcess = spawn('npx', ['tsx', 'server.ts'], {
+        shell: true,
+        env: {
+          ...process.env,
+          PORT: PORT.toString(),
+          MONGODB_URI: '', // Force MockDB mode
+          MONGODB_COMMAND_URI: '',
+          MONGODB_QUERY_URI: '',
+          ENABLE_MOCK_AUTH: 'true',
+          FIREBASE_PROJECT_ID: '', // Force Mock Auth Mode
+          FIREBASE_SERVICE_ACCOUNT_BASE64: '', // Force Mock Auth Mode
+          NODE_ENV: 'development'
+        },
+        stdio: 'pipe',
+      });
+
+      // Wait for server to start
+      await new Promise<void>((resolve, reject) => {
+        let started = false;
+        let fullOutput = "";
+        serverProcess.stdout?.on('data', (data) => {
+          fullOutput += data.toString();
+          if (fullOutput.includes('Server running on') && !started) {
+            started = true;
+            setTimeout(resolve, 1000);
+          }
+        });
+        serverProcess.on('error', reject);
+      });
+
+      console.log(`[Test] Server is up! Executing Saved Opportunities validations...`);
+
+      const payload = {
+        user_id: "mock_user_123",
+        email: "mock@example.com",
+        name: "Mock User",
+        picture: "https://avatar.url"
+      };
+      const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64");
+      const encodedPayload = Buffer.from(JSON.stringify(payload)).toString("base64");
+      const syncToken = `${header}.${encodedPayload}.mocksignature`;
+
+      console.log(`[Test] Syncing user profile to initialize mock user...`);
+      const syncRes = await fetch(`http://127.0.0.1:${PORT}/api/v1/auth/sync`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${syncToken}`
+        },
+        body: JSON.stringify({
+          name: "Mock User",
+          college: "Test University",
+          year: "3rd Year",
+          field: "Computer Science",
+          skills: ["React", "TypeScript"]
+        })
+      });
+      if (!syncRes.ok) throw new Error(`Sync failed with status: ${syncRes.status}`);
+
+      const mockToken = process.env.MOCK_VALID_TOKEN || "MOCK_VALID_TOKEN";
+      const authHeaders = {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${mockToken}`
+      };
+
+      // 1. Fetch available opportunities
+      const oppsRes = await fetch(`http://127.0.0.1:${PORT}/api/v1/opportunities`);
+      if (!oppsRes.ok) throw new Error(`Failed to fetch opportunities: ${oppsRes.status}`);
+      const oppsData = (await oppsRes.json()) as any;
+      const opportunityId = oppsData.items[0]?.id || "mock_opp_id_999";
+      console.log(`[Test] Target opportunity ID: ${opportunityId}`);
+
+      // 2. Fetch initially saved opportunities (should be empty)
+      const fetchInitialRes = await fetch(`http://127.0.0.1:${PORT}/api/v1/users/me/saved-opportunities`, {
+        headers: authHeaders
+      });
+      const fetchInitialData = await fetchInitialRes.json() as any;
+      console.log(`[Test] fetchInitialData:`, JSON.stringify(fetchInitialData));
+      expect(fetchInitialData.items.length).toBe(0);
+      expect(fetchInitialData.total).toBe(0);
+
+      // 3. Toggle Bookmark (Add)
+      const toggleRes1 = await fetch(`http://127.0.0.1:${PORT}/api/v1/opportunities/${opportunityId}/bookmark`, {
+        method: 'POST',
+        headers: authHeaders
+      });
+      const toggleData1 = await toggleRes1.json() as any;
+      expect(toggleData1.saved).toBe(true);
+
+      // 4. Fetch saved opportunities (should have 1)
+      const fetchAfterAddRes = await fetch(`http://127.0.0.1:${PORT}/api/v1/users/me/saved-opportunities`, {
+        headers: authHeaders
+      });
+      const fetchAfterAddData = await fetchAfterAddRes.json() as any;
+      expect(fetchAfterAddData.items.length).toBe(1);
+      expect(fetchAfterAddData.total).toBe(1);
+      expect(fetchAfterAddData.items[0].id).toBe(opportunityId);
+
+      // 5. Toggle Bookmark (Remove)
+      const toggleRes2 = await fetch(`http://127.0.0.1:${PORT}/api/v1/opportunities/${opportunityId}/bookmark`, {
+        method: 'POST',
+        headers: authHeaders
+      });
+      const toggleData2 = await toggleRes2.json() as any;
+      expect(toggleData2.saved).toBe(false);
+
+      // 6. Fetch saved opportunities (should be empty again)
+      const fetchAfterRemoveRes = await fetch(`http://127.0.0.1:${PORT}/api/v1/users/me/saved-opportunities`, {
+        headers: authHeaders
+      });
+      const fetchAfterRemoveData = await fetchAfterRemoveRes.json() as any;
+      expect(fetchAfterRemoveData.items.length).toBe(0);
+      expect(fetchAfterRemoveData.total).toBe(0);
+
+      console.log(`[Test] All Saved Opportunities validations passed.`);
+      
+      serverProcess.kill('SIGKILL');
+      
+    } catch (error: any) {
+      console.error(error);
+      throw error;
+    }
+  }, 30000); // 30s timeout
+});


### PR DESCRIPTION
- closes #301

### Description
This PR implements the "Saved Opportunities" bookmarking feature, allowing users to save and retrieve opportunities they are interested in. It also includes critical bug fixes for our `MockDB` engine to ensure accurate end-to-end testing and eliminates previous TypeScript compiler errors.

### Changes Made
- **Bookmarking Endpoints**: 
  - Added `POST /api/v1/opportunities/:id/bookmark` to toggle the saved state of an opportunity for the authenticated user.
  - Added `GET /api/v1/users/me/saved-opportunities` to fetch and populate the user's saved opportunities.
- **MockDB Engine Fixes (`src/api/db.ts`)**:
  - **Shared Memory Instance**: Fixed a bug where `dbCommand` (writes) and `dbQuery` (reads) were instantiating isolated `MockDB` environments. They now properly share the same mock state.
  - **$in Operator Support**: Added support for the `$in` operator inside `$or` queries, allowing the backend to correctly resolve arrays of IDs during mock data fetching.
- **API Bug Fixes**:
  - Updated the un-bookmarking logic to safely delete records by `{ userId, opportunityId }` instead of relying on `_id` generation, preventing 500 Internal Server Errors in mock environments.
- **Codebase Health**:
  - Resolved a duplicate `countDocuments` TypeScript compilation error in `db.ts`.
- **Integration Testing**:
  - Added `tests/test-saved-opportunities.ts` which robustly tests the entire flow: initial empty fetches, adding bookmarks, data validation, and un-bookmarking, utilizing properly mocked Firebase JWT authentication.

### Testing Performed
- [x] Verified `toggleBookmark` correctly inserts/deletes entries and returns accurate boolean states.
- [x] Verified `getSavedOpportunities` correctly hydrates saved entries with full opportunity metadata.
- [x] Passed all integration tests (`npm run test tests/test-saved-opportunities.ts`).
- [x] Ran linter (`npm run lint`) to ensure no compilation/type errors.
