### PR TITLE
[Feature]: Bulk notification management and optimized mark-as-read

### DIFF
--- a/src/api/controllers/notificationController.ts
+++ b/src/api/controllers/notificationController.ts
@@ -108,3 +108,55 @@ export const markAllRead = async (req: Request, res: Response) => {
     res.status(500).json({ error: "Internal Server Error" });
   }
 };
+
+export const markBulkRead = async (req: Request, res: Response) => {
+  try {
+    const user = req.user;
+    const { notificationIds, all } = req.body;
+    if (!dbCommand) return res.status(503).json({ error: "Database not available" });
+
+    const collection = dbCommand.collection("notifications");
+
+    if (!Array.isArray(notificationIds) && !all) {
+      return res.status(400).json({ error: "Invalid payload: notificationIds must be an array or all must be true" });
+    }
+
+    let filter: any = { userId: user.uid, read: { $ne: true } };
+
+    if (!all && Array.isArray(notificationIds) && notificationIds.length > 0) {
+      const oids = notificationIds.map((id: string) => safeObjectId(id) || id);
+      filter._id = { $in: oids };
+    }
+
+    if ((dbCommand as any).isMock) {
+      let updatedCount = 0;
+      if ((collection as any).data) {
+        (collection as any).data.forEach((n: any) => {
+          if (n.userId === user.uid && n.read !== true) {
+            let match = false;
+            if (all || !notificationIds || notificationIds.length === 0) {
+              match = true;
+            } else {
+              match = notificationIds.includes(n.id) || notificationIds.includes(n._id?.toString());
+            }
+            if (match) {
+              n.read = true;
+              n.isRead = true;
+              updatedCount++;
+            }
+          }
+        });
+      }
+      return res.json({ updatedCount });
+    } else {
+      const result = await collection.updateMany(
+        filter,
+        { $set: { read: true, isRead: true } }
+      );
+      res.json({ updatedCount: result.modifiedCount });
+    }
+  } catch (err: any) {
+    console.error("PUT /api/v1/notifications/read-bulk error:", err);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+};

--- a/src/api/routes/notificationRoutes.ts
+++ b/src/api/routes/notificationRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { getNotifications, markRead, markAllRead } from "../controllers/notificationController.js";
+import { getNotifications, markRead, markAllRead, markBulkRead } from "../controllers/notificationController.js";
 import { authMiddleware } from "../../middleware/auth.js";
 
 const router = Router();
@@ -7,5 +7,6 @@ const router = Router();
 router.get("/notifications", authMiddleware, getNotifications);
 router.post("/notifications/:id/read", authMiddleware, markRead);
 router.post("/notifications/read-all", authMiddleware, markAllRead);
+router.put("/notifications/read-bulk", authMiddleware, markBulkRead);
 
 export default router;

--- a/tests/test-bulk-notifications.ts
+++ b/tests/test-bulk-notifications.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { markBulkRead } from '../src/api/controllers/notificationController.js';
+
+// Mock the db dependencies
+let mockNotifications: any[] = [];
+
+vi.mock('../src/api/db.js', () => {
+  return {
+    dbCommand: {
+      isMock: true,
+      collection: (name: string) => {
+        if (name === "notifications") {
+          return {
+            data: mockNotifications,
+            updateMany: vi.fn() // Just in case it calls it, but we set isMock: true
+          };
+        }
+      }
+    }
+  };
+});
+
+// Since safeObjectId is used, we might need to mock it if it breaks, but it's safe to let it run
+vi.mock('../src/lib/utils.js', () => {
+  return {
+    safeObjectId: (id: string) => id // Mock safeObjectId to just return the string for testing
+  };
+});
+
+describe('Bulk Notifications API - markBulkRead', () => {
+  
+  beforeEach(() => {
+    // Reset mock data before each test
+    mockNotifications = [
+      { id: "notif1", userId: "testUser1", read: false, type: "test" },
+      { id: "notif2", userId: "testUser1", read: false, type: "test" },
+      { id: "notif3", userId: "testUser1", read: true, type: "test" },
+      { id: "notif4", userId: "otherUser", read: false, type: "test" }
+    ];
+  });
+
+  it('should mark specific notifications as read using notificationIds array', async () => {
+    let responseData: any;
+    let statusCode = 200;
+
+    const req = {
+      user: { uid: 'testUser1' },
+      body: { notificationIds: ['notif1'] }
+    } as any;
+
+    const res = {
+      status: vi.fn().mockImplementation((code: number) => { statusCode = code; return res; }),
+      json: vi.fn().mockImplementation((data: any) => { responseData = data; return res; })
+    } as any;
+
+    await markBulkRead(req, res);
+
+    expect(statusCode).toBe(200);
+    expect(responseData).toBeDefined();
+    expect(responseData.updatedCount).toBe(1);
+    
+    // Verify it updated in the array
+    const n1 = mockNotifications.find(n => n.id === 'notif1');
+    expect(n1.read).toBe(true);
+    expect(n1.isRead).toBe(true);
+    
+    // Ensure others were not affected
+    const n2 = mockNotifications.find(n => n.id === 'notif2');
+    expect(n2.read).toBe(false);
+  });
+
+  it('should mark all unread notifications as read when all=true', async () => {
+    let responseData: any;
+    let statusCode = 200;
+
+    const req = {
+      user: { uid: 'testUser1' },
+      body: { all: true }
+    } as any;
+
+    const res = {
+      status: vi.fn().mockImplementation((code: number) => { statusCode = code; return res; }),
+      json: vi.fn().mockImplementation((data: any) => { responseData = data; return res; })
+    } as any;
+
+    await markBulkRead(req, res);
+
+    expect(statusCode).toBe(200);
+    expect(responseData).toBeDefined();
+    expect(responseData.updatedCount).toBe(2); // notif1 and notif2 were unread
+    
+    // Verify it updated in the array
+    const n1 = mockNotifications.find(n => n.id === 'notif1');
+    const n2 = mockNotifications.find(n => n.id === 'notif2');
+    expect(n1.read).toBe(true);
+    expect(n2.read).toBe(true);
+    
+    // Ensure other user's notification wasn't affected
+    const n4 = mockNotifications.find(n => n.id === 'notif4');
+    expect(n4.read).toBe(false);
+  });
+
+  it('should return 400 Bad Request if neither notificationIds nor all is provided', async () => {
+    let responseData: any;
+    let statusCode = 200;
+
+    const req = {
+      user: { uid: 'testUser1' },
+      body: {}
+    } as any;
+
+    const res = {
+      status: vi.fn().mockImplementation((code: number) => { statusCode = code; return res; }),
+      json: vi.fn().mockImplementation((data: any) => { responseData = data; return res; })
+    } as any;
+
+    await markBulkRead(req, res);
+
+    expect(statusCode).toBe(400);
+    expect(responseData.error).toMatch(/Invalid payload/);
+  });
+});


### PR DESCRIPTION
- closes #302

### Description
This PR introduces a new bulk operation endpoint to improve the user experience of clearing system alerts. As users accumulate notifications, manually marking them as read one-by-one becomes tedious. This endpoint allows the frontend to dispatch a single request to mark multiple (or all) unread notifications as read.

### Changes Made
* **New Route:** Added `PUT /api/notifications/read-bulk` to `notificationRoutes.ts`.
* **New Controller Logic:** Added `markBulkRead` in `notificationController.ts`.
  * Accepts an array of specific `notificationIds` or a `{ "all": true }` flag.
  * Ensures payload validation.
  * Safely scopes the update query to the authenticated `req.user.id` so users cannot manipulate notifications belonging to others.
  * Executes an optimized, single database query (`updateMany`) instead of multiple single updates.
  * Returns the count of successfully updated documents (`updatedCount`).
* **Automated Testing:** Added `tests/test-bulk-notifications.ts` using Vitest to verify all three core scenarios (specific IDs, all flag, and malformed payload validations).

### How to Test
1. Make a `PUT` request to `/api/notifications/read-bulk`.
2. Pass `{ "all": true }` to mark all of the authenticated user's unread notifications as read.
3. Pass `{ "notificationIds": ["id1", "id2"] }` to mark specific notifications as read.
4. Verify that the response returns the count of updated notifications and that only the authenticated user's notifications were affected.
5. All automated unit tests can be verified by running `npm run test tests/test-bulk-notifications.ts`.

### Impact
Improves system performance and UX by allowing bulk notification management without spamming the backend with individual requests.
