### PR TITLE
fix: standardize dedupe hash to SHA-256 across scraper and DNL

### DIFF
--- a/src/workers/scraperWorker.ts
+++ b/src/workers/scraperWorker.ts
@@ -32,7 +32,7 @@ export const scraperWorker = new Worker(
     const title = `Mock Opportunity from ${domain} - ${Date.now()}`;
     const organization = `Mock Org ${domain}`;
     const dedupeHash = crypto
-      .createHash("md5")
+      .createHash("sha256")
       .update(`${domain}:${title}:${organization}`)
       .digest("hex");
 


### PR DESCRIPTION
Closes #336

Changes scraperWorker.ts from MD5 to SHA-256 to match deduplicator.ts, fixing cross-system deduplication mismatch.