### PR TITLE
fix(test): exclude e2e Playwright tests from Vitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,18 @@ Open your browser and navigate to `http://localhost:5173`.
 - **Manually Run Scrapers:** `npm run scrape`
 - **Check Database Connectivity:** `npm run test-mongo`
 
-### 7. Optional Docker & Redis Setup
+### 7. Running Tests
+YuvaHub separates unit/integration tests from end-to-end (e2e) tests:
+- **Unit & Integration Tests (Vitest):** Runs standard backend and controller validation tests:
+  ```bash
+  npm test
+  ```
+- **End-to-End Tests (Playwright):** Runs browser automation and frontend flow tests:
+  ```bash
+  npm run test:e2e
+  ```
+
+### 8. Optional Docker & Redis Setup
 Running Docker is **optional** for local development. `npm run dev` works out-of-the-box without Docker by running background tasks in local fallback mode.
 
 If you wish to test BullMQ queues or Meilisearch indexing locally with Redis, ensure Docker Desktop is running and start the containers:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     environment: 'node',
     fileParallelism: false, // Run tests sequentially to avoid DB collisions
     include: ['tests/**/*.ts', 'src/**/validationTest.ts'],
+    exclude: ['tests/e2e/**'],
     testTimeout: 30000, // Some DB operations might take a while
   },
 });


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Summary

This PR resolves a test suite conflict where Vitest was loading Playwright e2e test files under `tests/e2e`, leading to syntax and environment errors on startup.

---

## 🔗 Related Issue

issue : #284

---

## ✨ Changes Made

- **`vitest.config.ts`**: Added `exclude: ['tests/e2e/**']` to the Vitest config to prevent Vitest from scanning or executing Playwright tests.
- **`README.md`**: Added a new section documenting the separate test execution commands for unit/integration tests (`npm test`) and E2E tests (`npm run test:e2e`).

---

## 🧪 Testing

- [x] Tested locally (confirmed Vitest does not run e2e spec files anymore)
- [x] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)

---

## 📸 Screenshots

N/A

---

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [x] I have updated the documentation (if required).
- [x] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.
