### PR TITLE
fix: prevent analytics buffer from dropping events during active flush

### DIFF
--- a/src/api/analytics.ts
+++ b/src/api/analytics.ts
@@ -59,8 +59,8 @@ export class AnalyticsBuffer {
       );
     }
 
-    // 4. If still over capacity after flush, drop oldest events
-    if (this.buffer.length > this.maxBufferSize) {
+    // 4. If still over capacity and not currently flushing, drop oldest events
+    if (this.buffer.length > this.maxBufferSize && !this.isFlushing) {
       const excess = this.buffer.length - this.maxBufferSize;
       this.buffer.splice(0, excess);
       if (!this.overflowWarned) {


### PR DESCRIPTION
Closes #358

When isFlushing is true, events were being dropped even though a flush was in progress. Added !this.isFlushing guard to retain events for the next flush cycle.