### PR TITLE
fix: suppress pdf-parse default export TS error in resumeWorker

### DIFF
--- a/src/workers/resumeWorker.ts
+++ b/src/workers/resumeWorker.ts
@@ -2,6 +2,7 @@ import { Worker, Job } from "bullmq";
 import { connection } from "../queues/connection";
 import { MongoClient, ObjectId } from "mongodb";
 import dotenv from "dotenv";
+// @ts-expect-error — pdf-parse ESM bundle lacks default export; CJS fallback works at runtime
 import pdfParse from "pdf-parse";
 import { GoogleGenAI, Type } from "@google/genai";
 import { normalizeSkills } from "../services/skillTaxonomy";


### PR DESCRIPTION
Closes #359

pdf-parse ESM bundle lacks default export causing TS1192. @ts-expect-error silences the false positive — runtime CJS fallback resolves correctly.