### PR TITLE
fix: cast firebaseConfig for firestoreDatabaseId access

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -24,7 +24,7 @@ export const auth = initializeAuth(app, {
   popupRedirectResolver: browserPopupRedirectResolver
 });
 
-export const db = getFirestore(app, firebaseConfig.firestoreDatabaseId);
+export const db = getFirestore(app, (firebaseConfig as any).firestoreDatabaseId);
 
 import { doc, getDocFromServer } from 'firebase/firestore';
 


### PR DESCRIPTION
Closes #360

firestoreDatabaseId exists in the JSON config but the inferred TS type doesn't include it. as any cast allows the runtime value to reach getFirestore().