### PR TITLE
Fix: Resolve long-running integration test timeouts and mock DB issues (Fixes #291)

### DIFF
--- a/src/api/db.ts
+++ b/src/api/db.ts
@@ -174,6 +174,22 @@ export class MemoryCollection {
           }
         }
       }
+      if (update.$push) {
+        for (const key in update.$push) {
+          if (!Array.isArray(item[key])) {
+            item[key] = [];
+          }
+          const val = update.$push[key];
+          if (val && val.$each) {
+             item[key].push(...val.$each);
+             if (val.$slice !== undefined) {
+               item[key] = item[key].slice(val.$slice);
+             }
+          } else {
+             item[key].push(val);
+          }
+        }
+      }
       return { modifiedCount: 1 };
     }
     if (options.upsert) {

--- a/tests/test-resume-pipeline.ts
+++ b/tests/test-resume-pipeline.ts
@@ -13,13 +13,16 @@ describe('test-resume-pipeline.ts', () => {
   console.log("[Test] Starting Resume Pipeline Test");
   const uri = process.env.MONGODB_URI || "mongodb://localhost:27017";
   const dbName = process.env.MONGODB_DB_NAME || "yuvahub";
-  const mongoClient = new MongoClient(uri);
+ const mongoClient = new MongoClient(uri, {
+  serverSelectionTimeoutMS: 2000,
+  connectTimeoutMS: 2000,
+});
 
-  try {
-    await mongoClient.connect();
-    console.log("[Test] Connected to MongoDB");
+try {
+  await mongoClient.connect();
+  console.log("[Test] Connected to MongoDB");
 
-    // 1. Mock Resume Text (as if parsed from PDF)
+  // 1. Mock Resume Text (as if parsed from PDF)
     const mockResumeText = `
       John Doe
       Education:
@@ -135,4 +138,4 @@ describe('test-resume-pipeline.ts', () => {
       // Not throwing to allow suite to pass without local dbs
     }
   });
-});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     environment: 'node',
     fileParallelism: false, // Run tests sequentially to avoid DB collisions
     include: ['tests/**/*.ts', 'src/**/validationTest.ts'],
+    exclude: ['tests/e2e/**/*.ts', 'node_modules/**'],
     testTimeout: 120000, // Increased timeout for long-running integration tests
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
     environment: 'node',
     fileParallelism: false, // Run tests sequentially to avoid DB collisions
     include: ['tests/**/*.ts', 'src/**/validationTest.ts'],
-    testTimeout: 30000, // Some DB operations might take a while
+    testTimeout: 120000, // Increased timeout for long-running integration tests
   },
 });


### PR DESCRIPTION
## Description
This PR addresses issue #291 where long-running integration tests were timing out at the default 30s limit and failing during local runs. It also addresses related broken tests in the test suite that were mistakenly executing E2E logic or failing due to incomplete mock DB operators.

## Changes Made
- **Vitest Timeout Increased**: Increased the `testTimeout` inside `vitest.config.ts` from 30 seconds to 120 seconds to give database-dependent integration tests and API stubs ample time to complete.
- **E2E Test Exclusion**: Excluded Playwright tests (`tests/e2e/**/*.ts`) from Vitest's scope to prevent `test.describe` method collisions. 
- **MockDB `$push` Support**: Added `$push` operator support to the `MemoryCollection` within `src/api/db.ts` to fix the offline fallback mock DB. This resolves the `Refresh token reuse detected` failure in `test-auth-refresh.ts`.
- **Syntax Fixes**: Fixed a dangling bracket syntax error (`Expected "finally" but found ")"`) within `tests/test-resume-pipeline.ts`.

## Related Issues
Fixes #291 

## Testing Instructions
1. Run `npm run test` locally to verify that the Vitest suite executes cleanly.
2. Verify that `tests/test-saved-opportunities.ts` and `tests/test-auth-refresh.ts` pass reliably without hanging or false-positive token rotation failures.
