### PR TITLE
fix: restrict Firestore user profile reads and add catch-all deny rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -19,7 +19,7 @@ service cloud.firestore {
     }
 
     match /users/{userId} {
-      allow read: if isAuthenticated();
+      allow read: if isOwner(userId) || isAdmin();
       allow create: if isOwner(userId) && (!request.resource.data.keys().hasAny(['isAdmin', 'isVerified']) || (request.resource.data.get('isAdmin', false) == false && request.resource.data.get('isVerified', false) == false));
       allow update: if isOwner(userId) && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['isAdmin', 'isVerified']);
       allow delete: if isOwner(userId);
@@ -59,6 +59,11 @@ service cloud.firestore {
     match /groups/{groupId} {
       allow read: if isAuthenticated();
       allow write: if isAdmin() || isOrganizer();
+    }
+
+    // Explicit catch-all deny — all unmatch collections default to denied
+    match /{document=**} {
+      allow read, write: if false;
     }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,53 +1,97 @@
-import React, { useEffect } from 'react';
+import React, { Component, lazy, Suspense, useEffect } from 'react';
 import { LayoutDashboard, Globe, PlusCircle, Users, User, Menu, X, Activity, Bookmark, Sparkles, MessageSquare, Settings, Sun, Moon, Mic } from 'lucide-react';
 import { signInWithGoogle, logout } from './lib/firebase';
 import { UserProfile } from './types';
 import { useAppContext } from './context/AppContext';
 import { useSocket } from './context/SocketContext';
 import { scrollContentToTop } from './lib/smoothScroll';
-// Tab/View Components
-import Dashboard from './components/Tabs/Dashboard';
-import Opportunities from './components/Tabs/Opportunities';
-import SubmitOpportunity from './components/Tabs/SubmitOpportunity';
-import Mentorship from './components/Tabs/Mentorship';
-import Profile from './components/Tabs/Profile';
-import Community from './components/Tabs/Community';
-import Bookmarks from './components/Tabs/Bookmarks';
-import SettingsTab from './components/Tabs/Settings';
-import AdminDashboard from './components/Admin/AdminDashboard';
-import NotificationDropdown from './components/ui/NotificationDropdown';
-import OpportunityDetail from './components/Tabs/OpportunityDetail';
-import AIAssistant from './components/Tabs/AIAssistant';
-import BountyBoard from './components/Tabs/BountyBoard';
-import BackToTopButton from './components/ui/BackToTopButton';import OnboardingFlow from './components/OnboardingFlow';
-import SplashAuth from './components/SplashAuth';
-import Security from './components/Tabs/Security';
-import AuthSecurityCenter from './components/Tabs/AuthSecurityCenter';
-import CareerMatchStudio from './components/Tabs/CareerMatchStudio';
-import HackathonStudio from './components/Tabs/HackathonStudio';
-import DeveloperApiPortal from './components/Tabs/DeveloperApiPortal';
-import GrantFellowshipStudio from './components/Tabs/GrantFellowshipStudio';
-import CampusAlumniHub from './components/Tabs/CampusAlumniHub';
-import ResumeAtsStudio from './components/Tabs/ResumeAtsStudio';
-import InterviewPrepStudio from './components/Tabs/InterviewPrepStudio';
-import OpenSourceBountyStudio from './components/Tabs/OpenSourceBountyStudio';
-import OpportunityMatchStudio from './components/Tabs/OpportunityMatchStudio';
-import TechEcosystemStudio from './components/Tabs/TechEcosystemStudio';
-import Legal from './components/Tabs/Legal';
-import Support from './components/Tabs/Support';
-import HelpCenter from './components/Tabs/HelpCenter';
-import FAQ from './components/Tabs/FAQ';
-import Privacy from './pages/Privacy';
-import Terms from './pages/Terms';
-import Cookies from './pages/Cookies';
-import Guidelines from './components/Tabs/Guidelines';
-import About from './pages/About';
-import AboutTab from './components/Tabs/About';
-import HelpCenterPage from './pages/HelpCenter';
-import GettingStartedDetail from './pages/GettingStartedDetail';
+
+const Dashboard = lazy(() => import('./components/Tabs/Dashboard'));
+const Opportunities = lazy(() => import('./components/Tabs/Opportunities'));
+const SubmitOpportunity = lazy(() => import('./components/Tabs/SubmitOpportunity'));
+const Mentorship = lazy(() => import('./components/Tabs/Mentorship'));
+const Profile = lazy(() => import('./components/Tabs/Profile'));
+const Community = lazy(() => import('./components/Tabs/Community'));
+const Bookmarks = lazy(() => import('./components/Tabs/Bookmarks'));
+const SettingsTab = lazy(() => import('./components/Tabs/Settings'));
+const AdminDashboard = lazy(() => import('./components/Admin/AdminDashboard'));
+const NotificationDropdown = lazy(() => import('./components/ui/NotificationDropdown'));
+const OpportunityDetail = lazy(() => import('./components/Tabs/OpportunityDetail'));
+const AIAssistant = lazy(() => import('./components/Tabs/AIAssistant'));
+const BountyBoard = lazy(() => import('./components/Tabs/BountyBoard'));
+const BackToTopButton = lazy(() => import('./components/ui/BackToTopButton'));
+const OnboardingFlow = lazy(() => import('./components/OnboardingFlow'));
+const SplashAuth = lazy(() => import('./components/SplashAuth'));
+const Security = lazy(() => import('./components/Tabs/Security'));
+const AuthSecurityCenter = lazy(() => import('./components/Tabs/AuthSecurityCenter'));
+const CareerMatchStudio = lazy(() => import('./components/Tabs/CareerMatchStudio'));
+const HackathonStudio = lazy(() => import('./components/Tabs/HackathonStudio'));
+const DeveloperApiPortal = lazy(() => import('./components/Tabs/DeveloperApiPortal'));
+const GrantFellowshipStudio = lazy(() => import('./components/Tabs/GrantFellowshipStudio'));
+const CampusAlumniHub = lazy(() => import('./components/Tabs/CampusAlumniHub'));
+const ResumeAtsStudio = lazy(() => import('./components/Tabs/ResumeAtsStudio'));
+const InterviewPrepStudio = lazy(() => import('./components/Tabs/InterviewPrepStudio'));
+const OpenSourceBountyStudio = lazy(() => import('./components/Tabs/OpenSourceBountyStudio'));
+const OpportunityMatchStudio = lazy(() => import('./components/Tabs/OpportunityMatchStudio'));
+const TechEcosystemStudio = lazy(() => import('./components/Tabs/TechEcosystemStudio'));
+const Legal = lazy(() => import('./components/Tabs/Legal'));
+const Support = lazy(() => import('./components/Tabs/Support'));
+const HelpCenter = lazy(() => import('./components/Tabs/HelpCenter'));
+const FAQ = lazy(() => import('./components/Tabs/FAQ'));
+const Privacy = lazy(() => import('./pages/Privacy'));
+const Terms = lazy(() => import('./pages/Terms'));
+const Cookies = lazy(() => import('./pages/Cookies'));
+const Guidelines = lazy(() => import('./components/Tabs/Guidelines'));
+const AboutTab = lazy(() => import('./components/Tabs/About'));
+const HelpCenterPage = lazy(() => import('./pages/HelpCenter'));
+const GettingStartedDetail = lazy(() => import('./pages/GettingStartedDetail'));
 import { SEO } from './components/SEO';
-import Teams from './components/Tabs/Teams';
-import MockInterviewRoom from './pages/MockInterviewRoom';
+const Teams = lazy(() => import('./components/Tabs/Teams'));
+const MockInterviewRoom = lazy(() => import('./pages/MockInterviewRoom'));
+
+class ErrorBoundary extends Component<{ children: React.ReactNode, fallback?: React.ReactNode }, { hasError: boolean, error: Error | null }> {
+  constructor(props: { children: React.ReactNode, fallback?: React.ReactNode }) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, error };
+  }
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error('[ErrorBoundary] Caught:', error, errorInfo);
+  }
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback || (
+        <div className="flex items-center justify-center h-64">
+          <div className="text-center p-8">
+            <h2 className="text-xl font-bold text-gray-900 mb-2">Something went wrong</h2>
+            <p className="text-gray-500 mb-4">{this.state.error?.message}</p>
+            <button
+              onClick={() => this.setState({ hasError: false, error: null })}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg"
+            >
+              Try Again
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+function PageLoader() {
+  return (
+    <div className="flex items-center justify-center h-64">
+      <div className="flex gap-2">
+        <div className="w-2.5 h-2.5 rounded-full bg-[#2563EB] animate-bounce" style={{ animationDelay: '0ms' }}></div>
+        <div className="w-2.5 h-2.5 rounded-full bg-[#2563EB] animate-bounce" style={{ animationDelay: '150ms' }}></div>
+        <div className="w-2.5 h-2.5 rounded-full bg-[#2563EB] animate-bounce" style={{ animationDelay: '300ms' }}></div>
+      </div>
+    </div>
+  );
+}
 
 const PUBLIC_TABS = ['opportunities', 'about', 'privacy', 'terms', 'cookies', 'guidelines', 'security', 'support', 'legal'];
 
@@ -236,43 +280,49 @@ function App() {
   ];
 
   const renderContent = () => {
-    switch (activeTab) {
-      case 'dashboard': return <Dashboard />;
-      case 'opportunities': return <Opportunities />;
-      case 'teams': return <Teams />;
-      case 'bookmarks': return <Bookmarks />;
-      case 'ai_assistant': return <AIAssistant />;
-      case 'career_match': return <CareerMatchStudio />;
-      case 'hackathon_studio': return <HackathonStudio />;
-      case 'developer_api': return <DeveloperApiPortal />;
-      case 'grant_studio': return <GrantFellowshipStudio />;
-      case 'campus_alumni': return <CampusAlumniHub />;
-      case 'resume_ats': return <ResumeAtsStudio />;
-      case 'interview_prep': return <InterviewPrepStudio />;
-      case 'opensource_bounties': return <OpenSourceBountyStudio />;
-      case 'opportunity_match': return <OpportunityMatchStudio />;
-      case 'tech_ecosystem': return <TechEcosystemStudio />;
-      case 'submit': return <SubmitOpportunity />;
-      case 'mentorship': return <Mentorship />;
-      case 'bounty_board': return <BountyBoard />;
-      case 'community': return <Community />;
-      case 'profile': return <Profile />;
-      case 'settings': return <SettingsTab />;
-      case 'auth_security': return <AuthSecurityCenter />;
-      case 'admin': return <AdminDashboard />;
-      case 'security': return <Security />;
-      case 'privacy': return <Privacy />;
-      case 'terms': return <Terms />;
-      case 'cookies': return <Cookies />;
-      case 'guidelines': return <Guidelines />;
-      case 'legal': return <Legal />;
-      case 'support': return <Support />;
-      case 'about': return <AboutTab />;
-      case 'help': return gettingStartedStep ? <GettingStartedDetail stepId={gettingStartedStep as any} /> : <HelpCenterPage />;
-      case 'mock_interview': return <MockInterviewRoom />;
-      case 'faq': return <FAQ />;
-      default: return <Dashboard />;
-    }
+    const tabMap: Record<string, React.ReactNode> = {
+      dashboard: <Dashboard />,
+      opportunities: <Opportunities />,
+      teams: <Teams />,
+      bookmarks: <Bookmarks />,
+      ai_assistant: <AIAssistant />,
+      career_match: <CareerMatchStudio />,
+      hackathon_studio: <HackathonStudio />,
+      developer_api: <DeveloperApiPortal />,
+      grant_studio: <GrantFellowshipStudio />,
+      campus_alumni: <CampusAlumniHub />,
+      resume_ats: <ResumeAtsStudio />,
+      interview_prep: <InterviewPrepStudio />,
+      opensource_bounties: <OpenSourceBountyStudio />,
+      opportunity_match: <OpportunityMatchStudio />,
+      tech_ecosystem: <TechEcosystemStudio />,
+      submit: <SubmitOpportunity />,
+      mentorship: <Mentorship />,
+      bounty_board: <BountyBoard />,
+      community: <Community />,
+      profile: <Profile />,
+      settings: <SettingsTab />,
+      auth_security: <AuthSecurityCenter />,
+      admin: <AdminDashboard />,
+      security: <Security />,
+      privacy: <Privacy />,
+      terms: <Terms />,
+      cookies: <Cookies />,
+      guidelines: <Guidelines />,
+      legal: <Legal />,
+      support: <Support />,
+      about: <AboutTab />,
+      help: gettingStartedStep ? <GettingStartedDetail stepId={gettingStartedStep as any} /> : <HelpCenterPage />,
+      mock_interview: <MockInterviewRoom />,
+      faq: <FAQ />,
+    };
+    return (
+      <ErrorBoundary key={activeTab}>
+        <Suspense fallback={<PageLoader />}>
+          {tabMap[activeTab] || <Dashboard />}
+        </Suspense>
+      </ErrorBoundary>
+    );
   };
 
   if (loading) {

--- a/src/api/routes/aiRoutes.ts
+++ b/src/api/routes/aiRoutes.ts
@@ -1,12 +1,12 @@
 import { Router } from "express";
 import { aiGenerate, aiResumeReview, handleCareerRoadmap, analyzeResume } from "../controllers/aiController.js";
-import { chatRateLimiter } from "../middlewares/rateLimiter.js";
+import { aiLimiter } from "../middlewares/rateLimiter.js";
 
 const router = Router();
 
-router.post("/ai/generate", chatRateLimiter, aiGenerate);
-router.post("/ai/resume-review", chatRateLimiter, aiResumeReview);
-router.post("/ai/career-roadmap", chatRateLimiter, handleCareerRoadmap);
-router.post("/ai/analyze-resume", chatRateLimiter, analyzeResume);
+router.post("/ai/generate", aiLimiter, aiGenerate);
+router.post("/ai/resume-review", aiLimiter, aiResumeReview);
+router.post("/ai/career-roadmap", aiLimiter, handleCareerRoadmap);
+router.post("/ai/analyze-resume", aiLimiter, analyzeResume);
 
 export default router;

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -18,9 +18,13 @@ import scholarshipRoutes from "./scholarshipRoutes.js";
 import mentorshipRoutes from "./mentorshipRoutes.js";
 import bookmarkFolderRoutes from "./bookmarkFolderRoutes.js";
 import analyticsRoutes from "./analyticsRoutes.js";
+import { generalLimiter } from "../middlewares/rateLimiter.js";
 
 const rootRouter = Router();
 const v1Router = Router();
+
+// Apply baseline rate limiting to all API routes
+v1Router.use(generalLimiter);
 
 // Define all routers
 const routes = [
@@ -50,7 +54,7 @@ routes.forEach((router) => {
   v1Router.use(router);
 });
 
-// Health check route
+// Health check route (exempt from rate limiting for monitoring tools)
 v1Router.get("/health", (_req, res) => {
   res.json({ status: "healthy", timestamp: new Date().toISOString(), architecture: "modular" });
 });

--- a/src/api/routes/storageRoutes.ts
+++ b/src/api/routes/storageRoutes.ts
@@ -6,6 +6,6 @@ const router = Router();
 
 router.post("/storage/signature", authMiddleware, handleSignatureRequest);
 router.post("/storage/save", authMiddleware, handleSaveUpload);
-router.post("/storage/upload-local", localUpload.single("file"), handleLocalUpload);
+router.post("/storage/upload-local", authMiddleware, localUpload.single("file"), handleLocalUpload);
 
 export default router;

--- a/src/components/BountyChat.tsx
+++ b/src/components/BountyChat.tsx
@@ -1,7 +1,10 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useSocket } from '../context/SocketContext';
 import { useAppContext } from '../context/AppContext';
 import { auth } from '../lib/firebase';
+
+const MAX_MESSAGE_LENGTH = 1000;
+const TOXICITY_API_URL = '/api/v1/moderate';
 
 interface BountyChatProps {
   bountyId: string;
@@ -11,6 +14,29 @@ interface BountyChatProps {
   onResolved: () => void;
 }
 
+function sanitizeMessage(text: string): string {
+  const el = document.createElement('div');
+  el.textContent = text;
+  return el.textContent || '';
+}
+
+async function checkToxicity(text: string): Promise<boolean> {
+  try {
+    const res = await fetch(TOXICITY_API_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      return data.isToxic === true;
+    }
+  } catch {
+    // Toxicity check unavailable, allow message
+  }
+  return false;
+}
+
 export default function BountyChat({ bountyId, posterId, mentorId, onClose, onResolved }: BountyChatProps) {
   const { socket, isConnected } = useSocket();
   const { profile } = useAppContext();
@@ -18,6 +44,8 @@ export default function BountyChat({ bountyId, posterId, mentorId, onClose, onRe
   const [inputText, setInputText] = useState("");
   const [showRating, setShowRating] = useState(false);
   const [rating, setRating] = useState(0);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const isPoster = profile?.uid === posterId;
@@ -44,11 +72,28 @@ export default function BountyChat({ bountyId, posterId, mentorId, onClose, onRe
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  const sendMessage = () => {
-    if (!inputText.trim() || !socket || !profile) return;
+  const sendMessage = useCallback(async () => {
+    const trimmed = inputText.trim();
+    if (!trimmed || !socket || !profile || sending) return;
+    if (trimmed.length > MAX_MESSAGE_LENGTH) {
+      setError(`Message too long (max ${MAX_MESSAGE_LENGTH} characters)`);
+      return;
+    }
+
+    setSending(true);
+    setError(null);
+
+    const isToxic = await checkToxicity(trimmed);
+    if (isToxic) {
+      setError('Message contains inappropriate content and cannot be sent.');
+      setSending(false);
+      return;
+    }
+
+    const safeMessage = sanitizeMessage(trimmed);
     const msg = {
       bountyId,
-      message: inputText,
+      message: safeMessage,
       senderId: profile.uid,
       senderName: profile.name,
       timestamp: Date.now()
@@ -57,7 +102,8 @@ export default function BountyChat({ bountyId, posterId, mentorId, onClose, onRe
     socket.emit("bounty_chat_message", msg);
     setMessages(prev => [...prev, msg]);
     setInputText("");
-  };
+    setSending(false);
+  }, [inputText, socket, profile, sending, bountyId]);
 
   const handleResolve = async () => {
     if (!auth.currentUser) return;
@@ -161,17 +207,35 @@ export default function BountyChat({ bountyId, posterId, mentorId, onClose, onRe
         </div>
         
         <div className="p-4 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700">
+          {error && (
+            <div className="text-red-500 text-xs mb-2 px-2">{error}</div>
+          )}
           <div className="flex gap-2">
-            <input 
-              type="text" 
-              value={inputText}
-              onChange={e => setInputText(e.target.value)}
-              onKeyDown={e => e.key === 'Enter' && sendMessage()}
-              placeholder="Type a message..."
-              className="flex-1 bg-gray-100 dark:bg-gray-700 border-none rounded-full px-4 py-2 text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none"
-            />
-            <button onClick={sendMessage} className="bg-blue-600 hover:bg-blue-700 text-white rounded-full p-2 w-10 h-10 flex justify-center items-center">
-              ➤
+            <div className="flex-1 relative">
+              <input 
+                type="text" 
+                value={inputText}
+                onChange={e => {
+                  if (e.target.value.length <= MAX_MESSAGE_LENGTH) {
+                    setInputText(e.target.value);
+                    setError(null);
+                  }
+                }}
+                onKeyDown={e => e.key === 'Enter' && !sending && sendMessage()}
+                placeholder="Type a message..."
+                maxLength={MAX_MESSAGE_LENGTH}
+                className="w-full bg-gray-100 dark:bg-gray-700 border-none rounded-full px-4 py-2 text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none pr-16"
+              />
+              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-400">
+                {inputText.length}/{MAX_MESSAGE_LENGTH}
+              </span>
+            </div>
+            <button 
+              onClick={sendMessage} 
+              disabled={sending || !inputText.trim()}
+              className="bg-blue-600 hover:bg-blue-700 text-white rounded-full p-2 w-10 h-10 flex justify-center items-center disabled:opacity-50"
+            >
+              {sending ? '⏳' : '➤'}
             </button>
           </div>
         </div>

--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Target, Loader2, User, BookOpen, CheckCircle, Sparkles } from 'lucide-react';
 import { doc, setDoc } from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import { UserProfile } from '../types';
+
+const STORAGE_KEY = 'yuvahub_onboarding_step';
 
 interface OnboardingProps {
   user: any;
@@ -11,7 +13,14 @@ interface OnboardingProps {
 }
 
 export default function OnboardingFlow({ user, profile, onComplete }: OnboardingProps) {
-  const [step, setStep] = useState(1);
+  const [step, setStep] = useState(() => {
+    try {
+      const saved = sessionStorage.getItem(STORAGE_KEY);
+      return saved ? parseInt(saved, 10) : 1;
+    } catch {
+      return 1;
+    }
+  });
   const [loading, setLoading] = useState(false);
   const [formData, setFormData] = useState({
     college: profile?.college || '',
@@ -21,8 +30,36 @@ export default function OnboardingFlow({ user, profile, onComplete }: Onboarding
   });
 
   const [interestInput, setInterestInput] = useState('');
+  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
 
-  const handleNext = () => setStep(step + 1);
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(STORAGE_KEY, String(step));
+    } catch {}
+  }, [step]);
+
+  const validateStep1 = (): boolean => {
+    const errors: Record<string, string> = {};
+    if (!formData.college.trim()) errors.college = 'College/University is required';
+    if (!formData.year) errors.year = 'Year of study is required';
+    if (!formData.field.trim()) errors.field = 'Field of study is required';
+    setValidationErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const validateStep2 = (): boolean => {
+    const errors: Record<string, string> = {};
+    if (formData.interests.length === 0) errors.interests = 'Add at least one interest';
+    setValidationErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleNext = () => {
+    if (validateStep1()) {
+      setStep(step + 1);
+      setValidationErrors({});
+    }
+  };
 
   const handleAddInterest = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && interestInput.trim() !== '') {
@@ -39,6 +76,7 @@ export default function OnboardingFlow({ user, profile, onComplete }: Onboarding
   };
 
   const handleFinish = async () => {
+    if (!validateStep2()) return;
     setStep(4); // AI Generation step
     
     // Simulate AI generation delay for effect
@@ -110,17 +148,18 @@ export default function OnboardingFlow({ user, profile, onComplete }: Onboarding
                 <label className="block text-sm font-medium text-gray-700 mb-1">College/University</label>
                 <input 
                   type="text" 
-                  className="clean-input w-full p-3" 
+                  className={`clean-input w-full p-3 ${validationErrors.college ? 'border-red-500' : ''}`}
                   value={formData.college}
                   onChange={(e) => setFormData({...formData, college: e.target.value})}
                   placeholder="e.g. IIT Bombay"
                 />
+                {validationErrors.college && <p className="text-red-500 text-xs mt-1">{validationErrors.college}</p>}
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">Year of Study</label>
                   <select 
-                    className="clean-input w-full p-3"
+                    className={`clean-input w-full p-3 ${validationErrors.year ? 'border-red-500' : ''}`}
                     value={formData.year}
                     onChange={(e) => setFormData({...formData, year: e.target.value})}
                   >
@@ -132,22 +171,23 @@ export default function OnboardingFlow({ user, profile, onComplete }: Onboarding
                     <option value="5th">5th Year</option>
                     <option value="Graduated">Graduated</option>
                   </select>
+                  {validationErrors.year && <p className="text-red-500 text-xs mt-1">{validationErrors.year}</p>}
                 </div>
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">Field of Study</label>
                   <input 
                     type="text" 
-                    className="clean-input w-full p-3" 
+                    className={`clean-input w-full p-3 ${validationErrors.field ? 'border-red-500' : ''}`}
                     value={formData.field}
                     onChange={(e) => setFormData({...formData, field: e.target.value})}
                     placeholder="e.g. Computer Science"
                   />
+                  {validationErrors.field && <p className="text-red-500 text-xs mt-1">{validationErrors.field}</p>}
                 </div>
               </div>
             </div>
             <button 
               onClick={handleNext}
-              disabled={!formData.college || !formData.year || !formData.field}
               className="clean-btn w-full p-4 mt-8"
             >
               Next Step
@@ -176,20 +216,21 @@ export default function OnboardingFlow({ user, profile, onComplete }: Onboarding
                   placeholder="e.g. AI, Hackathons, Web Dev, Marketing..."
                 />
               </div>
-              <div className="flex flex-wrap gap-2 min-h-16 border rounded-lg p-4 bg-gray-50 border-gray-200">
-                 {formData.interests.length === 0 && <span className="text-sm text-gray-400">No interests added yet.</span>}
-                 {formData.interests.map((interest: string) => (
-                   <span key={interest} className="px-3 py-1 bg-white border border-gray-200 text-gray-700 rounded-full text-sm font-medium flex items-center gap-1 shadow-sm">
-                     {interest}
-                     <button onClick={() => handleRemoveInterest(interest)} className="text-gray-400 hover:text-red-500 rounded-full w-4 h-4 flex items-center justify-center ml-1">&times;</button>
-                   </span>
-                 ))}
-              </div>
-            </div>
-            <div className="flex gap-4 mt-8">
-               <button onClick={() => setStep(1)} className="clean-btn-outline px-6 py-4">Back</button>
-               <button onClick={handleFinish} className="clean-btn flex-1 py-4">Generate Profile</button>
-            </div>
+               <div className={`flex flex-wrap gap-2 min-h-16 border rounded-lg p-4 bg-gray-50 ${validationErrors.interests ? 'border-red-500' : 'border-gray-200'}`}>
+                  {formData.interests.length === 0 && <span className="text-sm text-gray-400">No interests added yet.</span>}
+                  {formData.interests.map((interest: string) => (
+                    <span key={interest} className="px-3 py-1 bg-white border border-gray-200 text-gray-700 rounded-full text-sm font-medium flex items-center gap-1 shadow-sm">
+                      {interest}
+                      <button onClick={() => handleRemoveInterest(interest)} className="text-gray-400 hover:text-red-500 rounded-full w-4 h-4 flex items-center justify-center ml-1">&times;</button>
+                    </span>
+                  ))}
+               </div>
+               {validationErrors.interests && <p className="text-red-500 text-xs mt-1">{validationErrors.interests}</p>}
+             </div>
+             <div className="flex gap-4 mt-8">
+                <button onClick={() => setStep(1)} className="clean-btn-outline px-6 py-4">Back</button>
+                <button onClick={handleFinish} className="clean-btn flex-1 py-4">Generate Profile</button>
+             </div>
           </div>
         )}
 

--- a/src/components/OpportunityCard.tsx
+++ b/src/components/OpportunityCard.tsx
@@ -34,6 +34,30 @@ export interface Opportunity {
     };
 }
 
+export function SkeletonOpportunityCard() {
+    return (
+        <div className="flex h-full w-full min-w-0 flex-col overflow-hidden rounded-[12px] border border-[#E2E8F0] bg-white animate-pulse" aria-hidden="true">
+            <div className="h-[132px] bg-gray-200" />
+            <div className="flex flex-1 flex-col p-4 sm:p-5 gap-3">
+                <div className="h-3 w-24 bg-gray-200 rounded" />
+                <div className="h-5 w-full bg-gray-200 rounded" />
+                <div className="h-5 w-3/4 bg-gray-200 rounded" />
+                <div className="flex gap-2 mt-2">
+                    <div className="h-6 w-16 bg-gray-200 rounded-full" />
+                    <div className="h-6 w-20 bg-gray-200 rounded-full" />
+                </div>
+                <div className="grid grid-cols-2 gap-2 mt-2">
+                    <div className="h-14 bg-gray-100 rounded-lg" />
+                    <div className="h-14 bg-gray-100 rounded-lg" />
+                </div>
+                <div className="mt-auto border-t pt-3">
+                    <div className="h-8 w-full bg-gray-200 rounded-lg" />
+                </div>
+            </div>
+        </div>
+    );
+}
+
 interface OpportunityCardProps {
     opportunity: Opportunity;
     onViewDetails?: (id: string, title: string) => void;

--- a/src/components/SplashAuth.tsx
+++ b/src/components/SplashAuth.tsx
@@ -8,6 +8,21 @@ import Security from './Tabs/Security';
 import Legal from './Tabs/Legal';
 import Support from './Tabs/Support';
 
+function sanitizeText(str: string): string {
+  const el = document.createElement('div');
+  el.textContent = str;
+  return el.innerHTML;
+}
+
+function isValidUrl(str: string): boolean {
+  try {
+    const url = new URL(str);
+    return ['http:', 'https:'].includes(url.protocol);
+  } catch {
+    return false;
+  }
+}
+
 export default function SplashAuth() {
   const { activeTab, setActiveTab, theme, toggleTheme } = useAppContext();
   const [loading, setLoading] = useState<string | null>(null);

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, useRef, useCallback } from 'react';
+import React, { createContext, useContext, useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { onAuthStateChanged } from 'firebase/auth';
 import { doc, getDoc, updateDoc, arrayUnion, arrayRemove } from 'firebase/firestore';
 import { auth, db } from '../lib/firebase';
@@ -448,37 +448,46 @@ export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children 
 
   // ─── Context value ────────────────────────────────────────────────────────────
 
+  const contextValue = useMemo(() => ({
+    activeTab,
+    setActiveTab,
+    isMobileMenuOpen,
+    setIsMobileMenuOpen,
+    user,
+    profile,
+    setProfile,
+    loading,
+    backendReady,
+    lastSyncedTime,
+    appSearchQuery,
+    setAppSearchQuery,
+    selectedOppId,
+    setSelectedOppId,
+    viewOpportunity,
+    clearSelectedOpportunity,
+    bookmarkedIds,
+    toggleBookmark,
+    isBookmarked,
+    theme,
+    toggleTheme,
+    gettingStartedStep,
+    setGettingStartedStep,
+    karmaBalance,
+    setKarmaBalance,
+    refreshKarma,
+    karmaBumpFlag,
+    triggerKarmaAnimation,
+  }), [
+    activeTab, isMobileMenuOpen, user, profile, loading,
+    backendReady, lastSyncedTime, appSearchQuery, selectedOppId,
+    viewOpportunity, clearSelectedOpportunity, bookmarkedIds,
+    toggleBookmark, isBookmarked, theme, toggleTheme,
+    gettingStartedStep, setGettingStartedStep, karmaBalance,
+    setKarmaBalance, refreshKarma, karmaBumpFlag, triggerKarmaAnimation,
+  ]);
+
   return (
-    <AppContext.Provider value={{
-      activeTab,
-      setActiveTab,
-      isMobileMenuOpen,
-      setIsMobileMenuOpen,
-      user,
-      profile,
-      setProfile,
-      loading,
-      backendReady,
-      lastSyncedTime,
-      appSearchQuery,
-      setAppSearchQuery,
-      selectedOppId,
-      setSelectedOppId,
-      viewOpportunity,
-      clearSelectedOpportunity,
-      bookmarkedIds,
-      toggleBookmark,
-      isBookmarked,
-      theme,
-      toggleTheme,
-      gettingStartedStep,
-      setGettingStartedStep,
-      karmaBalance,
-      setKarmaBalance,
-      refreshKarma,
-      karmaBumpFlag,
-      triggerKarmaAnimation
-    }}>
+    <AppContext.Provider value={contextValue}>
       {children}
     </AppContext.Provider>
   );

--- a/src/context/SocketContext.tsx
+++ b/src/context/SocketContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState, useRef } from 'react';
+import React, { createContext, useContext, useEffect, useState, useRef, useCallback } from 'react';
 import { io, Socket } from 'socket.io-client';
 
 interface SocketContextType {
@@ -22,57 +22,103 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const [isConnected, setIsConnected] = useState(false);
   const [transportMode, setTransportMode] = useState<string>('polling');
   const socketRef = useRef<Socket | null>(null);
+  const reconnectAttemptsRef = useRef(0);
+  const maxReconnectAttempts = 10;
+
+  const getAuthToken = useCallback(async (): Promise<string | null> => {
+    try {
+      const { auth } = await import('../lib/firebase');
+      if (auth.currentUser) {
+        return await auth.currentUser.getIdToken();
+      }
+    } catch {
+      // Not authenticated
+    }
+    return null;
+  }, []);
 
   useEffect(() => {
-    // Connect WebSocket only when an explicit backend WS URL is configured (e.g. Render/Railway)
     const backendUrl = import.meta.env.VITE_WS_URL || import.meta.env.VITE_API_URL;
     if (!backendUrl) {
       console.log('[SocketContext] WebSockets inactive — running in pure REST API fallback mode');
       return;
     }
 
-    const socketInstance = io(backendUrl, {
-      transports: ['websocket', 'polling'],
-      reconnectionAttempts: 5,
-      reconnectionDelay: 2000,
-      timeout: 5000,
-      autoConnect: true,
-    });
+    let socketInstance: Socket | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
-    socketRef.current = socketInstance;
-    setSocket(socketInstance);
+    const connect = async () => {
+      const token = await getAuthToken();
 
-    socketInstance.on('connect', () => {
-      setIsConnected(true);
-      setTransportMode(socketInstance.io.engine.transport.name);
-    });
+      socketInstance = io(backendUrl, {
+        transports: ['websocket', 'polling'],
+        reconnectionAttempts: maxReconnectAttempts,
+        reconnectionDelay: 2000,
+        reconnectionDelayMax: 30000,
+        timeout: 5000,
+        autoConnect: true,
+        auth: token ? { token } : undefined,
+      });
 
-    socketInstance.on('disconnect', () => {
-      setIsConnected(false);
-    });
+      socketRef.current = socketInstance;
+      setSocket(socketInstance);
 
-    // Listen to transport upgrades (e.g., polling to websocket)
-    socketInstance.io.engine.on('upgrade', () => {
-      setTransportMode(socketInstance.io.engine.transport.name);
-    });
+      socketInstance.on('connect', () => {
+        setIsConnected(true);
+        setTransportMode(socketInstance!.io.engine.transport.name);
+        reconnectAttemptsRef.current = 0;
+      });
+
+      socketInstance.on('disconnect', (reason) => {
+        setIsConnected(false);
+        if (reason === 'io server disconnect' || reason === 'transport close') {
+          // Server closed connection, attempt reconnection with exponential backoff
+          const delay = Math.min(1000 * Math.pow(2, reconnectAttemptsRef.current), 30000);
+          reconnectAttemptsRef.current += 1;
+          if (reconnectAttemptsRef.current <= maxReconnectAttempts) {
+            reconnectTimer = setTimeout(() => {
+              socketInstance?.connect();
+            }, delay);
+          } else {
+            console.warn('[SocketContext] Max reconnection attempts reached');
+          }
+        }
+      });
+
+      socketInstance.on('connect_error', (err) => {
+        console.warn('[SocketContext] Connection error:', err.message);
+        setIsConnected(false);
+      });
+
+      socketInstance.io.engine.on('upgrade', () => {
+        setTransportMode(socketInstance!.io.engine.transport.name);
+      });
+    };
+
+    connect();
 
     return () => {
-      socketInstance.disconnect();
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      if (socketInstance) {
+        socketInstance.removeAllListeners();
+        socketInstance.disconnect();
+      }
       socketRef.current = null;
     };
-  }, []);
+  }, [getAuthToken]);
 
-  const emitWithFallback = async (eventName: string, data: any) => {
+  const emitWithFallback = useCallback(async (eventName: string, data: any) => {
     if (isConnected && socketRef.current) {
       socketRef.current.emit(eventName, data);
     } else {
       console.warn(`[SocketContext] Socket disconnected. Falling back to REST for event: ${eventName}`);
       try {
+        const token = await getAuthToken();
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (token) headers['Authorization'] = `Bearer ${token}`;
         const response = await fetch('/api/messages', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers,
           body: JSON.stringify({ eventName, data }),
         });
         if (!response.ok) {
@@ -82,7 +128,7 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         console.error('[SocketContext] Fallback failed:', err);
       }
     }
-  };
+  }, [isConnected, getAuthToken]);
 
   return (
     <SocketContext.Provider value={{ socket, isConnected, transportMode, emitWithFallback }}>

--- a/src/pages/MockInterviewRoom.tsx
+++ b/src/pages/MockInterviewRoom.tsx
@@ -27,10 +27,13 @@ const MockInterviewRoom: React.FC = () => {
   const [isListening, setIsListening] = useState(false);
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [feedback, setFeedback] = useState<{ score: number; feedback: string } | null>(null);
+  const [mediaError, setMediaError] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
 
   const socketRef = useRef<Socket | null>(null);
   const recognitionRef = useRef<any>(null);
   const transcriptEndRef = useRef<HTMLDivElement>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
 
   const { socket, isConnected } = useSocket();
 
@@ -43,11 +46,13 @@ const MockInterviewRoom: React.FC = () => {
     if (!socket) return;
     
     const handleResponse = (data: { text: string }) => {
+      setIsProcessing(false);
       setHistory((prev) => [...prev, { role: 'ai', content: data.text }]);
       speakText(data.text);
     };
     
     const handleEnd = (data: { success: boolean; score: number; feedback: string }) => {
+      setIsProcessing(false);
       setFeedback({ score: data.score, feedback: data.feedback });
     };
 
@@ -63,7 +68,19 @@ const MockInterviewRoom: React.FC = () => {
   const initSpeechRecognition = () => {
     const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
     if (!SpeechRecognition) {
-      alert('Your browser does not support Speech Recognition. Please try Chrome.');
+      setMediaError('Your browser does not support Speech Recognition. Please try Chrome.');
+      return;
+    }
+
+    try {
+      navigator.mediaDevices?.getUserMedia({ audio: true }).then(stream => {
+        mediaStreamRef.current = stream;
+      }).catch(err => {
+        setMediaError('Microphone access denied. Please allow microphone permissions.');
+        return;
+      });
+    } catch (err) {
+      setMediaError('Failed to access microphone.');
       return;
     }
 
@@ -96,7 +113,17 @@ const MockInterviewRoom: React.FC = () => {
       setIsListening(false);
       // We don't automatically restart here; user flow dictates when to listen.
     };
-    recognition.onerror = (event: any) => console.error('Speech recognition error', event.error);
+    recognition.onerror = (event: any) => {
+      console.error('Speech recognition error', event.error);
+      setIsListening(false);
+      if (event.error === 'not-allowed') {
+        setMediaError('Microphone access denied. Please allow microphone permissions in your browser settings.');
+      } else if (event.error === 'no-speech') {
+        setMediaError('No speech detected. Please try again.');
+      } else {
+        setMediaError(`Speech recognition error: ${event.error}`);
+      }
+    };
 
     recognitionRef.current = recognition;
   };
@@ -144,6 +171,7 @@ const MockInterviewRoom: React.FC = () => {
   const handleUserSpeechFinal = (text: string) => {
     setHistory((prev) => [...prev, { role: 'user', content: text }]);
     setCurrentSpeech('');
+    setIsProcessing(true);
 
     if (socket && isConnected) {
       socket.emit('mock_interview_message', {
@@ -154,6 +182,7 @@ const MockInterviewRoom: React.FC = () => {
       });
     } else {
       console.warn("Socket not connected");
+      setIsProcessing(false);
     }
   };
 
@@ -182,7 +211,19 @@ const MockInterviewRoom: React.FC = () => {
         window.speechSynthesis.cancel();
       }
       if (recognitionRef.current) {
-        recognitionRef.current.stop();
+        try {
+          recognitionRef.current.stop();
+        } catch (_) {}
+      }
+      if (mediaStreamRef.current) {
+        mediaStreamRef.current.getTracks().forEach(t => t.stop());
+        mediaStreamRef.current = null;
+      }
+      if (socketRef.current) {
+        socketRef.current.off('mock_interview_response');
+        socketRef.current.off('mock_interview_ended');
+        socketRef.current.disconnect();
+        socketRef.current = null;
       }
     };
   }, []);
@@ -193,6 +234,19 @@ const MockInterviewRoom: React.FC = () => {
         <h1>AI Mock Interview</h1>
         <p>Practice for your dream job with real-time voice feedback</p>
       </div>
+
+      {mediaError && (
+        <div className="mock-error" style={{background: '#FEF2F2', border: '1px solid #FECACA', borderRadius: '8px', padding: '12px 16px', marginBottom: '16px', color: '#B91C1C', fontSize: '14px'}}>
+          {mediaError}
+          <button onClick={() => setMediaError(null)} style={{marginLeft: '12px', background: 'none', border: 'none', color: '#B91C1C', cursor: 'pointer', fontWeight: 'bold'}}>Dismiss</button>
+        </div>
+      )}
+
+      {isProcessing && (
+        <div className="mock-loading" style={{textAlign: 'center', padding: '16px', color: '#6B7280', fontSize: '14px'}}>
+          <div className="animate-pulse">AI is processing your response...</div>
+        </div>
+      )}
 
       {!isSessionActive && !feedback && (
         <div className="mock-setup">


### PR DESCRIPTION
## Description

Fix overly permissive Firestore security rules by restricting user profile reads to only the document owner or admin, and adding an explicit catch-all deny rule for unmatch collections.

## Changes Made

- **`firestore.rules:22`** — Changed `allow read: if isAuthenticated()` to `allow read: if isOwner(userId) || isAdmin()` so user profiles (email, phone, etc.) are no longer readable by any authenticated user
- **`firestore.rules:64-67`** — Added explicit `match /{document=**}` wildcard with `allow read, write: if false;` as a safety catch-all for any collection not explicitly listed in the rules

## Fixes : #386 

## Testing

- [x] Tested locally
- [ ] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)