### PR TITLE
fix: enforce server-only Gemini API key usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,10 +17,12 @@ MONGODB_DB_NAME=yuvahub
 # -------------------------------------------------------------------------
 # Google Gemini AI API Configuration
 # -------------------------------------------------------------------------
-# Required for AI features (Resume Review, Cover Letter Generation, AI Mentor chat).
-# Get a FREE API key from Google AI Studio in 1 click:
-# https://aistudio.google.com/
-GEMINI_API_KEY=YOUR_GEMINI_API_KEY_HERE
+# SERVER-ONLY SECRET — never prefix with VITE_ and never access from browser code.
+# Used only by the Express API, workers, and server-side Gemini services.
+# All frontend AI requests must go through /api/v1/ai/* backend routes.
+# Rotate any key that may previously have appeared in a deployed client bundle.
+# Get a key from Google AI Studio: https://aistudio.google.com/
+GEMINI_API_KEY=YOUR_SERVER_ONLY_GEMINI_API_KEY_HERE
 
 # -------------------------------------------------------------------------
 # Application URLs & CORS Configuration

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Provide these keys in your `.env` file to fully enable application databases and
 | :--- | :--- | :--- |
 | `MONGODB_URI` | Connection URI for the MongoDB Atlas Cluster. | MongoDB Atlas Dashboard |
 | `MONGODB_DB_NAME` | Target database collection name. | `yuvahub` |
-| `GEMINI_API_KEY` | Authentication key for Google Gemini model access. | [Google AI Studio](https://aistudio.google.com/) |
+| `GEMINI_API_KEY` | **Server-only secret.** Used by backend Gemini services; never expose it through Vite or browser code. | [Google AI Studio](https://aistudio.google.com/) |
 | `APP_URL` | Base host URL of the local or deployed server. | `http://localhost:3000` |
 | `FRONTEND_URL` | Allowed client origin to enforce CORS security policy. | `http://localhost:5173` (or Vercel URL) |
 | `VITE_EMAILJS_SERVICE_ID` | EmailJS service connection ID. | [EmailJS Dashboard](https://www.emailjs.com/) |

--- a/docs/GEMINI_KEY_SECURITY.md
+++ b/docs/GEMINI_KEY_SECURITY.md
@@ -1,0 +1,73 @@
+# Gemini API key security boundary
+
+## Security rule
+
+`GEMINI_API_KEY` is a server-only secret.
+
+It may be read by:
+
+- Express API controllers and `src/api/genai.ts`
+- Server-side services
+- Background workers
+- Local server-side test utilities
+
+It must never be read by:
+
+- React components
+- Browser hooks or contexts
+- Vite `define`
+- Any variable prefixed with `VITE_`
+- Direct browser requests to Google Gemini endpoints
+
+## Client flow
+
+Browser AI features call the backend:
+
+```text
+React UI
+  -> POST /api/v1/ai/generate
+  -> Express AI controller
+  -> src/api/genai.ts
+  -> Google Gemini
+```
+
+The browser receives only the generated response. It never receives the
+provider credential.
+
+## Automated protection
+
+The security-boundary test checks:
+
+- Vite does not define or inject `GEMINI_API_KEY`
+- Browser AI helpers use `/api/v1/ai/generate`
+- Browser modules do not import Gemini SDK packages
+- Browser modules do not call Google's Generative Language endpoint directly
+
+The production build additionally runs:
+
+```bash
+node scripts/verify-client-secrets.mjs
+```
+
+This scans generated client HTML, JavaScript, CSS, JSON and source maps before
+the server bundle is created. The build fails if it finds:
+
+- `GEMINI_API_KEY`
+- The configured Gemini key value
+- `generativelanguage.googleapis.com`
+- Browser-bundled Gemini SDK references
+
+## Required response to previous exposure
+
+Removing the key from source does not revoke a previously exposed credential.
+
+A repository or deployment maintainer must:
+
+1. Revoke or rotate the old Gemini key in Google AI Studio or Google Cloud.
+2. Store the replacement only in the backend deployment environment.
+3. Remove any `VITE_GEMINI_*` variables.
+4. Rebuild and redeploy.
+5. Run the bundle verification command.
+6. Review provider usage and billing for unexpected activity.
+
+Never paste the real key into test logs, screenshots, issues or pull requests.

--- a/package.json
+++ b/package.json
@@ -8,14 +8,16 @@
     "start:worker": "tsx src/worker.ts",
     "dev": "concurrently \"vite\" \"tsx server.ts\"",
     "dev:server": "tsx server.ts",
-    "build": "vite build && esbuild server.ts --bundle --platform=node --format=cjs --packages=external --sourcemap --outfile=dist/server.cjs",
+    "build": "vite build && node scripts/verify-client-secrets.mjs && esbuild server.ts --bundle --platform=node --format=cjs --packages=external --sourcemap --outfile=dist/server.cjs",
     "preview": "vite preview",
     "clean": "rm -rf dist",
     "lint": "tsc --noEmit",
     "scrape": "tsx scrape-cli.ts",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "verify:client-secrets": "node scripts/verify-client-secrets.mjs",
+    "test:client-secrets": "vitest run tests/client-secret-boundary.test.ts"
   },
   "dependencies": {
     "@bull-board/api": "^8.1.2",

--- a/scripts/verify-client-secrets.mjs
+++ b/scripts/verify-client-secrets.mjs
@@ -1,0 +1,140 @@
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import {
+  basename,
+  extname,
+  join,
+  relative,
+  resolve,
+} from "node:path";
+
+const projectRoot = resolve(import.meta.dirname, "..");
+const distDir = resolve(projectRoot, "dist");
+
+const TEXT_EXTENSIONS = new Set([
+  ".html",
+  ".js",
+  ".mjs",
+  ".css",
+  ".json",
+  ".map",
+  ".txt",
+  ".svg",
+]);
+
+const SERVER_ARTIFACTS = new Set([
+  "server.cjs",
+  "server.cjs.map",
+  "server.js",
+  "server.js.map",
+  "server.mjs",
+  "server.mjs.map",
+]);
+
+const forbiddenPatterns = [
+  {
+    label: "server-only environment variable name",
+    pattern: /GEMINI_API_KEY/g,
+  },
+  {
+    label: "direct Google Generative Language API endpoint",
+    pattern: /generativelanguage\.googleapis\.com/gi,
+  },
+  {
+    label: "Google Gemini SDK in the browser bundle",
+    pattern: /@google\/(?:genai|generative-ai)/g,
+  },
+];
+
+const configuredSecret = process.env.GEMINI_API_KEY?.trim();
+
+if (configuredSecret && configuredSecret.length >= 8) {
+  forbiddenPatterns.push({
+    label: "configured Gemini API key value",
+    pattern: new RegExp(
+      configuredSecret.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+      "g",
+    ),
+  });
+}
+
+function shouldScan(filePath) {
+  const fileName = basename(filePath).toLowerCase();
+
+  if (SERVER_ARTIFACTS.has(fileName)) {
+    return false;
+  }
+
+  return TEXT_EXTENSIONS.has(extname(fileName));
+}
+
+function collectFiles(directory) {
+  const files = [];
+
+  for (const entry of readdirSync(directory)) {
+    const absolutePath = join(directory, entry);
+    const stats = statSync(absolutePath);
+
+    if (stats.isDirectory()) {
+      files.push(...collectFiles(absolutePath));
+      continue;
+    }
+
+    if (shouldScan(absolutePath)) {
+      files.push(absolutePath);
+    }
+  }
+
+  return files;
+}
+
+if (!existsSync(distDir)) {
+  console.error(
+    "[client-secret-check] dist/ does not exist. Run the frontend build first.",
+  );
+  process.exit(1);
+}
+
+const clientFiles = collectFiles(distDir);
+const violations = [];
+
+for (const filePath of clientFiles) {
+  const contents = readFileSync(filePath, "utf8");
+
+  for (const { label, pattern } of forbiddenPatterns) {
+    pattern.lastIndex = 0;
+
+    if (pattern.test(contents)) {
+      violations.push({
+        file: relative(projectRoot, filePath),
+        label,
+      });
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    "[client-secret-check] Potential Gemini exposure detected in browser assets:",
+  );
+
+  for (const violation of violations) {
+    console.error(`- ${violation.file}: ${violation.label}`);
+  }
+
+  process.exit(1);
+}
+
+console.log(
+  `[client-secret-check] Passed: scanned ${clientFiles.length} browser build files.`,
+);
+console.log(
+  "[client-secret-check] Server bundles were excluded from this browser-only scan.",
+);
+console.log(
+  "[client-secret-check] No Gemini key, direct Google AI endpoint, or Gemini SDK reference was found in client assets.",
+);

--- a/tests/client-secret-boundary.test.ts
+++ b/tests/client-secret-boundary.test.ts
@@ -1,0 +1,108 @@
+import {
+  readFileSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import { extname, join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const projectRoot = resolve(import.meta.dirname, "..");
+
+const CLIENT_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+]);
+
+const FORBIDDEN_CLIENT_PATTERNS = [
+  /process\.env\.GEMINI_API_KEY/g,
+  /import\.meta\.env\.GEMINI_API_KEY/g,
+  /generativelanguage\.googleapis\.com/gi,
+  /from\s+["']@google\/(?:genai|generative-ai)["']/g,
+];
+
+function collectClientFiles(directory: string): string[] {
+  const files: string[] = [];
+
+  for (const entry of readdirSync(directory)) {
+    const absolutePath = join(directory, entry);
+    const stats = statSync(absolutePath);
+
+    if (stats.isDirectory()) {
+      files.push(...collectClientFiles(absolutePath));
+      continue;
+    }
+
+    if (
+      CLIENT_EXTENSIONS.has(extname(entry)) &&
+      !absolutePath.includes(`${join("src", "api")}`) &&
+      !absolutePath.includes(`${join("src", "workers")}`) &&
+      !absolutePath.includes(`${join("src", "consumers")}`) &&
+      !absolutePath.endsWith("applicationGenerator.ts") &&
+      !absolutePath.endsWith("embedding.ts") &&
+      !absolutePath.endsWith("toxicity.ts") &&
+      !absolutePath.includes(`${join("services", "agent")}`)
+    ) {
+      files.push(absolutePath);
+    }
+  }
+
+  return files;
+}
+
+describe("Gemini client/server security boundary", () => {
+  it("does not expose GEMINI_API_KEY through Vite configuration", () => {
+    const config = readFileSync(
+      join(projectRoot, "vite.config.ts"),
+      "utf8",
+    );
+
+    expect(config).not.toMatch(/define\s*:\s*\{[\s\S]*GEMINI_API_KEY/);
+    expect(config).not.toContain(
+      "'process.env.GEMINI_API_KEY'",
+    );
+    expect(config).toContain(
+      'loadEnv(mode, ".", ["VITE_", "SENTRY_"])',
+    );
+  });
+
+  it("keeps browser AI requests behind the Express proxy", () => {
+    const browserGeminiService = readFileSync(
+      join(projectRoot, "src", "services", "gemini.ts"),
+      "utf8",
+    );
+
+    expect(browserGeminiService).toContain(
+      'fetch("/api/v1/ai/generate"',
+    );
+    expect(browserGeminiService).not.toMatch(
+      /GoogleGenAI|GoogleGenerativeAI/,
+    );
+    expect(browserGeminiService).not.toMatch(
+      /GEMINI_API_KEY|generativelanguage\.googleapis\.com/,
+    );
+  });
+
+  it("finds no direct Gemini secret or SDK use in browser modules", () => {
+    const violations: string[] = [];
+
+    for (const filePath of collectClientFiles(
+      join(projectRoot, "src"),
+    )) {
+      const contents = readFileSync(filePath, "utf8");
+
+      for (const pattern of FORBIDDEN_CLIENT_PATTERNS) {
+        pattern.lastIndex = 0;
+
+        if (pattern.test(contents)) {
+          violations.push(
+            filePath.replace(`${projectRoot}/`, ""),
+          );
+        }
+      }
+    }
+
+    expect([...new Set(violations)]).toEqual([]);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,47 +1,46 @@
-import tailwindcss from '@tailwindcss/vite';
-import react from '@vitejs/plugin-react';
-import path from 'path';
-import {defineConfig, loadEnv} from 'vite';
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import path from "path";
+import { defineConfig, loadEnv } from "vite";
 import { viteSingleFile } from "vite-plugin-singlefile";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 
-export default defineConfig(({mode}) => {
-  const env = loadEnv(mode, '.', '');
+export default defineConfig(({ mode }) => {
+  // Only load variables that are intentionally used by the frontend build
+  // or by build-time Sentry tooling. Server-only secrets such as
+  // GEMINI_API_KEY are deliberately excluded from Vite's environment.
+  const env = loadEnv(mode, ".", ["VITE_", "SENTRY_"]);
+
   return {
     plugins: [
-      react(), 
-      tailwindcss(), 
+      react(),
+      tailwindcss(),
       viteSingleFile(),
       sentryVitePlugin({
         org: env.SENTRY_ORG || process.env.SENTRY_ORG,
         project: env.SENTRY_PROJECT || process.env.SENTRY_PROJECT,
         authToken: env.SENTRY_AUTH_TOKEN || process.env.SENTRY_AUTH_TOKEN,
-      })
+      }),
     ],
     build: {
-      sourcemap: true, // Generate sourcemaps for Sentry
-    },
-    define: {
-      'process.env.VITE_EMAILJS_SERVICE_ID': JSON.stringify(env.VITE_EMAILJS_SERVICE_ID),
-      'process.env.VITE_EMAILJS_TEMPLATE_ID': JSON.stringify(env.VITE_EMAILJS_TEMPLATE_ID),
-      'process.env.VITE_EMAILJS_PUBLIC_KEY': JSON.stringify(env.VITE_EMAILJS_PUBLIC_KEY),
+      sourcemap: true,
     },
     resolve: {
       alias: {
-        '@': path.resolve(__dirname, '.'),
+        "@": path.resolve(__dirname, "."),
       },
     },
     server: {
       // HMR is disabled in AI Studio via DISABLE_HMR env var.
-      // Do not modifyâ€”file watching is disabled to prevent flickering during agent edits.
-      hmr: process.env.DISABLE_HMR !== 'true',
+      // File watching is disabled there to prevent flickering during agent edits.
+      hmr: process.env.DISABLE_HMR !== "true",
       proxy: {
-        '/api': {
-          target: 'http://localhost:5000',
+        "/api": {
+          target: "http://localhost:5000",
           changeOrigin: true,
           secure: false,
         },
-      }
+      },
     },
   };
 });


### PR DESCRIPTION
# 🚀 Pull Request

## Description

Hardens YuvaHub’s Gemini integration so the Gemini API key remains exclusively on the server and cannot be included in generated frontend assets.

Fixes #397

## Security impact

The Gemini provider key must never be accessible to browser users.

This change establishes and automatically verifies the following boundary:

```text
Browser UI
  → YuvaHub Express API
  → Server-side Gemini integration
  → Google Gemini
```

The frontend receives generated responses but never receives the provider credential.

## Changes

### Vite environment boundary

* Restricted Vite environment loading to intentional `VITE_` and `SENTRY_` prefixes
* Prevented server-only environment variables from being loaded into Vite configuration
* Removed unnecessary compile-time environment substitutions
* Ensured `GEMINI_API_KEY` cannot be injected through Vite `define`

### Backend AI proxy

* Confirmed browser AI functionality uses YuvaHub’s backend `/api/v1/ai/*` routes
* Confirmed the browser Gemini helper does not import either Google Gemini SDK
* Confirmed browser code does not call Google’s Generative Language API directly
* Preserved the existing AI API response format

### Build-time protection

Added:

```text
scripts/verify-client-secrets.mjs
```

The production build now scans generated browser assets before bundling the server.

The build fails when it detects:

* `GEMINI_API_KEY`
* The configured Gemini secret value
* `generativelanguage.googleapis.com`
* `@google/genai`
* `@google/generative-ai`

The scan includes generated HTML, JavaScript, CSS, JSON, SVG, text files, and source maps.

### Regression tests

Added:

```text
tests/client-secret-boundary.test.ts
```

The tests verify:

* Vite does not expose `GEMINI_API_KEY`
* Vite loads only approved environment prefixes
* Browser AI requests use `/api/v1/ai/generate`
* Browser modules do not access the server-only environment variable
* Browser modules do not import Gemini SDK packages
* Browser modules do not call the provider API directly

### Documentation

* Marked `GEMINI_API_KEY` as a server-only secret in `.env.example`
* Updated the README environment-variable description
* Added Gemini key security and rotation documentation
* Documented the correct frontend-to-backend AI flow
* Documented deployment and verification requirements

## Key rotation requirement

Any Gemini API key that may previously have appeared in a deployed frontend bundle must be considered compromised.

The old key should be revoked and replaced in the backend deployment environment. The replacement key must not use a `VITE_` prefix.

No API keys are included in this PR.

## Validation

* [ ] Client-secret boundary tests passed
* [ ] TypeScript validation passed
* [ ] Production build passed
* [ ] Client bundle verification passed
* [ ] `GEMINI_API_KEY` is absent from browser assets
* [ ] Direct Google Generative Language URLs are absent from browser assets
* [ ] Gemini SDK packages are absent from browser assets
* [ ] Browser AI features call `/api/v1/ai/*`
* [ ] Browser AI functionality works through the backend
* [ ] Missing-key fallback behaviour tested
* [ ] Existing Gemini key rotated by a repository maintainer
* [ ] Replacement key stored only in the backend environment

## Test commands

```bash
npm run test:client-secrets
npm run lint
npm run build
npm run verify:client-secrets
```

## Testing evidence
<img width="1379" height="446" alt="Screenshot 2026-07-25 211550" src="https://github.com/user-attachments/assets/bf1484ef-4faa-4af3-9635-9a7589143c61" />
<img width="1388" height="246" alt="Screenshot 2026-07-25 211854" src="https://github.com/user-attachments/assets/37020cfa-eab0-4360-885c-465981008c96" />


## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [x] I have updated the documentation (if required).
- [x] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

❤️ Thank you for contributing!