### PR TITLE
fix: CQRS violation — write operations on read replica dbQuery

### DIFF
--- a/src/api/controllers/authController.ts
+++ b/src/api/controllers/authController.ts
@@ -93,7 +93,7 @@ export const authSync = async (req: Request, res: Response) => {
       });
     }
 
-    const usersCollection = dbQuery.collection("users");
+    const usersCollection = dbCommand.collection("users");
     const existingUser = await usersCollection.findOne({ uid });
 
     const role = email === "uditt490@gmail.com" ? "admin" : "student";

--- a/src/api/controllers/bookmarkController.ts
+++ b/src/api/controllers/bookmarkController.ts
@@ -39,7 +39,7 @@ export const addBookmark = async (req: Request, res: Response) => {
       return res.status(404).json({ error: "Opportunity not found" });
     }
 
-    const usersCollection = dbQuery.collection("users");
+    const usersCollection = dbCommand.collection("users");
     // Add to bookmarks, ensuring uniqueness (duplicate prevention)
     await usersCollection.updateOne(
       { uid: user.uid },
@@ -63,7 +63,7 @@ export const deleteBookmark = async (req: Request, res: Response) => {
       return res.status(400).json({ error: "Missing opportunityId" });
     }
 
-    const usersCollection = dbQuery.collection("users");
+    const usersCollection = dbCommand.collection("users");
     await usersCollection.updateOne(
       { uid: user.uid },
       { $pull: { bookmarks: opportunityId } }

--- a/src/api/controllers/scholarshipController.ts
+++ b/src/api/controllers/scholarshipController.ts
@@ -10,7 +10,7 @@ export const createScholarship = async (req: Request, res: Response, next: NextF
   try {
     if (!dbCommand || !dbQuery) return res.status(503).json({ success: false, error: "Database not available" });
     const parsedData = req.body;
-    const collection = dbQuery.collection("scholarships");
+    const collection = dbCommand.collection("scholarships");
     const result = await collection.insertOne(parsedData);
     res.status(201).json({ success: true, id: result.insertedId, ...parsedData });
   } catch (err: any) {
@@ -64,7 +64,7 @@ export const updateScholarship = async (req: Request, res: Response, next: NextF
     const rawId = req.params.id;
     const id = Array.isArray(rawId) ? rawId[0] : rawId;
     const parsedData = { ...req.body, updated_at: new Date() };
-    const collection = dbQuery.collection("scholarships");
+    const collection = dbCommand.collection("scholarships");
     const oid = safeObjectId(id);
     const queryId = oid || id;
 
@@ -80,7 +80,7 @@ export const deleteScholarship = async (req: Request, res: Response) => {
     if (!dbCommand || !dbQuery) return res.status(503).json({ error: "Database not available" });
     const rawId = req.params.id;
     const id = Array.isArray(rawId) ? rawId[0] : rawId;
-    const collection = dbQuery.collection("scholarships");
+    const collection = dbCommand.collection("scholarships");
     const oid = safeObjectId(id);
     const queryId = oid || id;
     let deleted = true;


### PR DESCRIPTION
## Description

This PR fixes a CQRS (Command Query Responsibility Segregation) violation where write operations (`insertOne`, `updateOne`, `deleteOne`) were being performed on the read replica connection (`dbQuery`) instead of the write connection (`dbCommand`).

Currently, three controllers acquire collection handles from `dbQuery` (intended for read-only queries) and then perform mutations on them. In production, where `queryUri` may point to a read-only MongoDB replica, all these writes silently fail — user profiles are never saved, bookmarks are never persisted, and scholarships are never created/updated/deleted. This works in development only because MockDB merges both pools into the same object.

This PR changes every write-targeted `dbQuery.collection(...)` call to `dbCommand.collection(...)`, ensuring mutations are always sent to the write-capable connection.

---

## Related Issue

* Closes #455

---

## Component(s) Affected

* [x] Backend (`server/`)
* [ ] Mobile app (`rhythma_flutter/`)
* [ ] Web app (`web/`)
* [ ] Landing page (`landing-page/`)
* [ ] Docs only (README, CONTRIBUTING, architecture, etc.)
* [ ] CI / tooling

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor (no behavior change)
* [ ] Tests
* [ ] Other:

---

## Testing Performed

### Commands executed

* [ ] `npm test`
* [x] `npm run lint`
* [x] `npm run build`
* [x] Manual verification

### Manually verified

* Confirmed all `dbQuery.collection("users")` and `dbQuery.collection("scholarships")` calls that perform writes are changed to `dbCommand.collection(...)`.
* Verified read-only queries (find, countDocuments) on `dbQuery` are preserved unchanged.
* Confirmed TypeScript compilation passes with no new errors.

### Edge cases considered

* All six affected call sites across three files were changed.
* Read-only query paths (getScholarships, getScholarshipById, validateEligibility) intentionally left on `dbQuery`.
* Controllers that already correctly use `dbCommand` for writes are untouched.

---

## API Documentation (required for any new/changed backend endpoint)

Not applicable. This PR does not modify any endpoint signatures or response shapes — it only changes which database connection is used internally.

---

## Documentation Updates

* [x] Not applicable

---

## Checklist

* [x] I have read `CONTRIBUTING.md`
* [ ] I rebased/merged the latest `main` into this branch
* [x] I tested my changes locally (see Testing Performed above)
* [x] This PR is scoped to one logical change
* [x] I did not commit any secrets, credentials, or real `.env` files
