### PR TITLE
fix: ReDoS regex injection in getComments (unauthenticated)

### DIFF
--- a/src/api/controllers/communityController.ts
+++ b/src/api/controllers/communityController.ts
@@ -189,8 +189,9 @@ export const getComments = async (req: Request, res: Response) => {
   try {
     const { postId } = req.params;
     if (dbQuery) {
+      const escapedPostId = postId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       const comments = await dbQuery.collection("comments")
-        .find({ $or: [{ postId }, { path: new RegExp('^,' + postId + ',') }] })
+        .find({ $or: [{ postId }, { path: new RegExp('^,' + escapedPostId + ',') }] })
         .sort({ createdAt: -1 })
         .toArray();
 


### PR DESCRIPTION
## Description

This PR fixes a ReDoS (Regular Expression Denial of Service) vulnerability in the `getComments` handler. The `postId` parameter from `req.params` was directly interpolated into a `RegExp` constructor without escaping special characters. An attacker could send a malicious `postId` like `(.*)*` to cause catastrophic backtracking, hanging the Node.js event loop.

The route `GET /community/posts/:postId/comments` has no authentication middleware, making this a server-wide DoS vector via a single unauthenticated GET request.

This PR escapes regex special characters in `postId` before passing it to the `RegExp` constructor, following standard secure coding practices.

---

## Related Issue

* Closes #456

---

## Component(s) Affected

* [x] Backend (`server/`)
* [ ] Mobile app (`rhythma_flutter/`)
* [ ] Web app (`web/`)
* [ ] Landing page (`landing-page/`)
* [ ] Docs only (README, CONTRIBUTING, architecture, etc.)
* [ ] CI / tooling

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor (no behavior change)
* [ ] Tests
* [ ] Other:

---

## Testing Performed

### Commands executed

* [ ] `npm test`
* [x] `npm run lint`
* [x] `npm run build`
* [x] Manual verification

### Manually verified

* Confirmed `postId` is escaped before RegExp construction.
* Verified normal postId values (ObjectId strings) still match correctly.
* Verified TypeScript compilation passes with no new errors.

### Edge cases considered

* ObjectId strings (24 hex chars) — no special chars, no change in behavior.
* postId with regex metacharacters like `.` or `+` — now safely escaped.
* Empty or missing postId — handled by Express route param validation.

---

## API Documentation (required for any new/changed backend endpoint)

Not applicable. This PR does not modify any endpoint signatures or response shapes.

---

## Documentation Updates

* [x] Not applicable

---

## Checklist

* [x] I have read `CONTRIBUTING.md`
* [ ] I rebased/merged the latest `main` into this branch
* [x] I tested my changes locally (see Testing Performed above)
* [x] This PR is scoped to one logical change
* [x] I did not commit any secrets, credentials, or real `.env` files
