### PR TITLE
fix: startDate filter hides active opportunities in Meilisearch path

### DIFF
--- a/src/api/controllers/opportunityController.ts
+++ b/src/api/controllers/opportunityController.ts
@@ -154,7 +154,7 @@ export async function getRankedOpportunities(database: any, profile: any, page: 
     const nowTime = new Date().getTime();
     items = items.filter((item: any) => {
       if (item.endDate && new Date(item.endDate).getTime() < nowTime) return false;
-      if (item.startDate && new Date(item.startDate).getTime() < nowTime) return false;
+      if (item.startDate && new Date(item.startDate).getTime() > nowTime) return false;
       if (item.deadlineDate && new Date(item.deadlineDate).getTime() < nowTime) return false;
       if (item.deadline && typeof item.deadline === 'string') {
         const dStr = item.deadline.toLowerCase();


### PR DESCRIPTION
## Description

This PR fixes a filtering bug in the Meilisearch path of `getRankedOpportunities()` where the `startDate` check incorrectly excluded opportunities with a past start date — even if they still had a future `endDate` or `deadlineDate`. For example, a year-long internship that started last month was hidden from all users.

The mock-DB fallback path used correct logic (`$gte` — only excludes future start dates), but the production Meilisearch path had the comparison inverted: it excluded items where `startDate < now` instead of `startDate > now`.

This PR changes the comparison from `< nowTime` to `> nowTime`, so only opportunities whose start date is in the future (not yet open) are excluded. Opportunities that have already started but not yet ended remain visible, matching the behavior of the mock-DB path.

---

## Related Issue

* Closes #458

---

## Component(s) Affected

* [x] Backend (`server/`)
* [ ] Mobile app (`rhythma_flutter/`)
* [ ] Web app (`web/`)
* [ ] Landing page (`landing-page/`)
* [ ] Docs only (README, CONTRIBUTING, architecture, etc.)
* [ ] CI / tooling

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor (no behavior change)
* [ ] Tests
* [ ] Other:

---

## Testing Performed

### Commands executed

* [ ] `npm test`
* [x] `npm run lint`
* [x] `npm run build`
* [x] Manual verification

### Manually verified

* Confirmed the comparison is now `> nowTime` (excludes future, not past).
* Manually traced the logic: past startDate + future endDate → now correctly included.
* Verified TypeScript compilation passes with no new errors.

### Edge cases considered

* Opportunity with past startDate and future endDate — now correctly visible.
* Opportunity with only startDate (no endDate) — still shows if started.
* Opportunity with future startDate — correctly excluded (not yet open).
* Opportunity with no startDate at all — filter is skipped, works as before.

---

## API Documentation (required for any new/changed backend endpoint)

Not applicable. This PR is a one-character comparison fix with no API surface change.

---

## Documentation Updates

* [x] Not applicable

---

## Checklist

* [x] I have read `CONTRIBUTING.md`
* [ ] I rebased/merged the latest `main` into this branch
* [x] I tested my changes locally (see Testing Performed above)
* [x] This PR is scoped to one logical change
* [x] I did not commit any secrets, credentials, or real `.env` files
