### PR TITLE
fix: race condition in karma daily login bonus (TOCTOU)

### DIFF
--- a/src/api/controllers/karmaController.ts
+++ b/src/api/controllers/karmaController.ts
@@ -40,21 +40,33 @@ export const awardKarma = async (req: Request, res: Response) => {
       if (type === 'daily_login') {
         const startOfDay = new Date();
         startOfDay.setHours(0, 0, 0, 0);
-        const existing = await dbCommand.collection("transactions").findOne({
+        const result = await dbCommand.collection("transactions").findOneAndUpdate(
+          {
+            userId: user.uid,
+            type: 'daily_login',
+            timestamp: { $gte: startOfDay.getTime() }
+          },
+          {
+            $setOnInsert: {
+              userId: user.uid,
+              amount,
+              type: 'daily_login',
+              timestamp: Date.now(),
+              metadata
+            }
+          },
+          { upsert: true, returnDocument: 'before' }
+        );
+        if (result?.value) return res.status(400).json({ error: "Daily login already claimed" });
+      } else {
+        await dbCommand.collection("transactions").insertOne({
           userId: user.uid,
-          type: 'daily_login',
-          timestamp: { $gte: startOfDay.getTime() }
+          amount,
+          type,
+          timestamp: Date.now(),
+          metadata
         });
-        if (existing) return res.status(400).json({ error: "Daily login already claimed" });
       }
-
-      await dbCommand.collection("transactions").insertOne({
-        userId: user.uid,
-        amount,
-        type,
-        timestamp: Date.now(),
-        metadata
-      });
     }
     res.json({ success: true, awarded: amount });
   } catch (err: any) {


### PR DESCRIPTION
## Description

This PR fixes a TOCTOU (Time-of-Check, Time-of-Use) race condition in the karma daily login bonus handler. The previous code used a separate `findOne` check followed by `insertOne` — if a user sent two concurrent requests, both could pass the check before either inserted, resulting in double-claimed bonuses (2000 karma instead of 1000).

This PR replaces the check-then-insert pattern with an atomic `findOneAndUpdate` upsert with `$setOnInsert`. The upsert ensures that if a daily_login transaction for the same user/day already exists, the operation is a no-op. The `returnDocument: 'before'` option returns the existing document if found, allowing the handler to return a 400 error.

Non-daily-login transactions (profile_setup, expired_report) continue using the simple `insertOne` path since they don't have the same race condition risk.

---

## Related Issue

* Closes #459

---

## Component(s) Affected

* [x] Backend (`server/`)
* [ ] Mobile app (`rhythma_flutter/`)
* [ ] Web app (`web/`)
* [ ] Landing page (`landing-page/`)
* [ ] Docs only (README, CONTRIBUTING, architecture, etc.)
* [ ] CI / tooling

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor (no behavior change)
* [ ] Tests
* [ ] Other:

---

## Testing Performed

### Commands executed

* [ ] `npm test`
* [x] `npm run lint`
* [x] `npm run build`
* [x] Manual verification

### Manually verified

* Confirmed `findOneAndUpdate` with upsert and `$setOnInsert` atomically prevents duplicates.
* Confirmed `returnDocument: 'before'` correctly returns the existing doc on match.
* Verified TypeScript compilation passes with no new errors.

### Edge cases considered

* First daily login of the day — upsert inserts, no existing doc, bonus awarded.
* Second request before first insert completes — upsert matches the same filter, `$setOnInsert` is a no-op, existing doc returned, 400 error sent.
* Non-login transaction types — use the simple `insertOne` path (no atomicity needed).
* Database connection failure — error propagates to existing catch handler.

---

## API Documentation (required for any new/changed backend endpoint)

Not applicable. This PR does not modify any endpoint signatures or response shapes — only the internal write path is changed.

---

## Documentation Updates

* [x] Not applicable

---

## Checklist

* [x] I have read `CONTRIBUTING.md`
* [ ] I rebased/merged the latest `main` into this branch
* [x] I tested my changes locally (see Testing Performed above)
* [x] This PR is scoped to one logical change
* [x] I did not commit any secrets, credentials, or real `.env` files
