### PR TITLE
fix: deadline scheduler Math.ceil() causes missed reminder windows

### DIFF
--- a/src/services/deadlineScheduler.ts
+++ b/src/services/deadlineScheduler.ts
@@ -131,7 +131,7 @@ export async function runDeadlineChecks(db: any): Promise<void> {
 
         // Calculate difference in days
         const timeDiff = deadline.getTime() - now.getTime();
-        const diffDays = Math.ceil(timeDiff / (1000 * 60 * 60 * 24));
+        const diffDays = Math.floor(timeDiff / (1000 * 60 * 60 * 24));
 
         // Trigger alerts on 7, 3, 2 (~48 hours), 1, or 0 days remaining
         if (![7, 3, 2, 1, 0].includes(diffDays)) {


### PR DESCRIPTION
## Description

This PR fixes a bug in the deadline scheduler where `Math.ceil()` was used to calculate days remaining, causing missed reminder windows for fractional-day deadlines.

The scheduler runs once every 24 hours and checks exact day values `[7, 3, 2, 1, 0]`. Using `Math.ceil()`, a deadline that is 7 days and 1 hour away produces `diffDays = 8`, which matches none of the trigger points. The reminder is completely missed because the next scan occurs after the optimal 7-day window has passed.

Changing to `Math.floor()` ensures that a deadline still 7.x days away correctly maps to day 7, so the reminder fires at the right time. Deadlines closer to 8 days away (e.g., 7.9) still correctly trigger at day 7, and the next scan at day ~6.9 maps to floor 6 (no duplicate).

---

## Related Issue

* Closes #497

---

## Component(s) Affected

* [x] Backend (`server/`)
* [ ] Mobile app (`rhythma_flutter/`)
* [ ] Web app (`web/`)
* [ ] Landing page (`landing-page/`)
* [ ] Docs only (README, CONTRIBUTING, architecture, etc.)
* [ ] CI / tooling

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor (no behavior change)
* [ ] Tests
* [ ] Other:

---

## Testing Performed

### Commands executed

* [ ] `npm test`
* [x] `npm run lint`
* [x] `npm run build`
* [x] Manual verification

### Manually verified

* Confirmed `Math.floor()` maps 7.1–7.9 days to 7 (correct trigger).
* Traced full timeline: -7.9→7 ✓, -6.9→6 ✗, -3.9→3 ✓, -2.9→2 ✓, -1.9→1 ✓, -0.9→0 ✓.
* Verified TypeScript compilation passes with no new errors.

### Edge cases considered

* Exact day boundary (7.0) — floor gives 7, same as ceil.
* Negative timeDiff (past deadline) — floor gives negative, excluded by array check.
* Zero timeDiff (due now) — floor gives 0, triggers correctly.

---

## API Documentation (required for any new/changed backend endpoint)

Not applicable.

---

## Documentation Updates

* [x] Not applicable

---

## Checklist

* [x] I have read `CONTRIBUTING.md`
* [ ] I rebased/merged the latest `main` into this branch
* [x] I tested my changes locally (see Testing Performed above)
* [x] This PR is scoped to one logical change
* [x] I did not commit any secrets, credentials, or real `.env` files
