### PR TITLE
fix: restrict CORS to specific origins instead of wildcard

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -29,16 +29,64 @@ Sentry.init({
 const app = express();
 const server = http.createServer(app);
 
-// Socket.IO Configuration
+// CORS helper: parse comma-separated FRONTEND_URL into allowed origins
+const getAllowedOrigins = (): string[] => {
+  const raw = process.env.FRONTEND_URL;
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+};
+
+const allowedOrigins = getAllowedOrigins();
+const isProduction = process.env.NODE_ENV === "production";
+
+if (isProduction && allowedOrigins.length === 0) {
+  console.error(
+    "[CORS] FRONTEND_URL is not configured. All requests will be blocked by CORS in production."
+  );
+}
+
+// Socket.IO CORS
 const io = new SocketIOServer(server, {
   cors: {
-    origin: process.env.FRONTEND_URL || "*",
+    origin: isProduction
+      ? allowedOrigins
+      : allowedOrigins.length > 0
+        ? allowedOrigins
+        : true,
     methods: ["GET", "POST"],
   },
 });
 setSocketIO(io);
 
-app.use(cors());
+// Express CORS
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      // Allow requests with no origin (server-to-server, mobile apps, curl)
+      if (!origin) return callback(null, true);
+
+      if (isProduction) {
+        if (allowedOrigins.includes(origin)) {
+          return callback(null, true);
+        }
+        return callback(new Error(`Origin "${origin}" not allowed by CORS`));
+      }
+
+      // Development: allow if origin is in the allowed list, or allow all
+      if (allowedOrigins.length === 0 || allowedOrigins.includes(origin)) {
+        return callback(null, true);
+      }
+      return callback(new Error(`Origin "${origin}" not allowed by CORS`));
+    },
+    methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "Authorization"],
+    credentials: true,
+    optionsSuccessStatus: 204,
+  })
+);
 app.use(express.json({ limit: "5mb" }));
 app.use(express.urlencoded({ limit: "5mb", extended: true }));
 

--- a/src/api/controllers/communityController.ts
+++ b/src/api/controllers/communityController.ts
@@ -257,16 +257,6 @@ export const editComment = async (req: Request, res: Response) => {
     if (!dbCommand || !dbQuery)
       return res.status(503).json({ error: "Database not available" });
 
-    const oid = typeof commentId === "string" ? safeObjectId(commentId) : null;
-    const queryId = oid || commentId;
-
-    const result = await dbCommand
-      .collection("comments")
-      .findOneAndUpdate(
-        { _id: queryId, postId },
-        { $set: { content, updatedAt: new Date() } },
-        { returnDocument: "after" },
-      );
     const oid = safeObjectId(commentIdStr);
     const queryId = oid || commentIdStr;
 
@@ -297,24 +287,6 @@ export const getComments = async (req: Request, res: Response) => {
       return res.status(400).json({ error: "Missing or invalid postId" });
     }
     if (dbQuery) {
-      const normalizedPostId = Array.isArray(postId) ? postId[0] : postId;
-
-      if (!normalizedPostId) {
-        return res.status(400).json({
-          success: false,
-          error: "Post ID is required.",
-        });
-      }
-
-      const escapedPostId = normalizedPostId.replace(
-        /[.*+?^${}()|[\]\\]/g,
-        "\\$&",
-      );
-      const comments = await dbQuery
-        .collection("comments")
-        .find({
-          $or: [{ postId }, { path: new RegExp("^," + escapedPostId + ",") }],
-        })
       const escapedPostId = postIdStr.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       const comments = await dbQuery.collection("comments")
         .find({ $or: [{ postId: postIdStr }, { path: new RegExp('^,' + escapedPostId + ',') }] })
@@ -329,14 +301,14 @@ export const getComments = async (req: Request, res: Response) => {
     res.json([
       {
         _id: "c_101",
-        postId,
+        postId: postIdStr,
         author: "Neha Sharma",
         content: "Great resource! Thanks for sharing the roadmap repo.",
         createdAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
       },
       {
         _id: "c_102",
-        postId,
+        postId: postIdStr,
         author: "Vikas Kumar",
         content: "Super helpful! Added to my study bookmarks.",
         createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Summary

Restricts CORS configuration to only allow specific trusted origins instead of the wildcard (`*`) default, preventing CSRF attacks and unauthorized cross-origin access.

---

## 🔗 Related Issue

Closes #465

---

## ✨ Changes Made

- **`server.ts`**: Replaced permissive `app.use(cors())` with a strict CORS configuration
  - Added `getAllowedOrigins()` helper that parses comma-separated origins from `FRONTEND_URL`
  - Production: blocks all origins not in the allowlist; logs error if `FRONTEND_URL` is unset
  - Development: allows all origins when `FRONTEND_URL` is unset, otherwise validates against the allowlist
  - Restricted HTTP methods to `GET, POST, PUT, PATCH, DELETE, OPTIONS`
  - Restricted allowed headers to `Content-Type, Authorization`
  - Enabled `credentials: true` for cookie/session support
- **Socket.IO CORS**: Uses the same `FRONTEND_URL` allowlist with production/development awareness
- **Pre-existing bug fix**: Removed duplicate variable declarations in `communityController.ts:editComment` and `getComments` that were blocking the server build

---

## 🧪 Testing

- [x] Tested locally (TypeScript type-check passes)
- [x] Tested locally (build succeeds)
- [ ] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)

---

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [ ] I have updated the documentation (if required).
- [ ] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

❤️ Thank you for contributing!
