### PR TITLE
fix: clean up Socket.IO listeners and rooms on disconnect to prevent listener leaks

### DIFF
--- a/src/socket/index.ts
+++ b/src/socket/index.ts
@@ -19,7 +19,9 @@ export const setupSocketEvents = () => {
     });
 
     socket.on("disconnect", () => {
-      console.log(`[Socket] User disconnected: ${socket.id}`);
+      socket.removeAllListeners();
+      socket.leaveAll();
+      console.log(`[Socket] Cleaned up listeners for socket ${socket.id}`);
     });
   });
 };


### PR DESCRIPTION
## 📝 Summary

Fix Socket.IO disconnect listener leak that causes accumulating event listeners on client reconnection. When clients experience transient network disconnections, the old socket's event listeners and room memberships are now properly cleaned up.

---

## 🔗 Related Issue

Closes #505

---

## ✨ Changes Made

- Added `socket.removeAllListeners()` in the disconnect handler to clean up all socket-bound event listeners
- Added `socket.leaveAll()` in the disconnect handler to remove the socket from all rooms
- Updated disconnect log message to reflect cleanup action

---

## 🧪 Testing

- [x] Tested locally
- [ ] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)

---

## 📸 Screenshots

N/A

---

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [ ] I have updated the documentation (if required).
- [ ] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---
