### PR TITLE
fix: add structured adapter failure reporting

### DIFF
--- a/docs/issue-392-adapter-reliability.md
+++ b/docs/issue-392-adapter-reliability.md
@@ -1,0 +1,55 @@
+# Issue #392 — adapter reliability
+
+## Repository mapping
+
+The issue refers to older files named `baseAdapter.ts`,
+`internshalaAdapter.ts`, `linkedinAdapter.ts`, and `unstopAdapter.ts`.
+
+The current repository implements opportunity adapters under:
+
+```text
+src/services/dnl/adapters/
+src/services/dnl/scheduler.ts
+```
+
+This patch applies the issue's reliability requirements to the current
+architecture.
+
+## Behaviour
+
+Each run now returns a structured result containing:
+
+- source
+- success/status
+- processed/inserted/duplicate/failure counts
+- duration
+- safe structured failure details
+
+Failures include a source, stage, code, retryability flag, timestamp and
+sanitised message.
+
+## Silent circuit-breaker failure fixed
+
+Previously the breaker fallback returned an empty JSON array. The dispatcher
+could then report a healthy run with zero payloads even though the fetch had
+failed.
+
+The fallback now carries an explicit failure marker. It is recorded as:
+
+```text
+FETCH_FAILED / fetch / retryable=true
+```
+
+## Isolation
+
+`runAdapters()` executes all supplied adapters and returns a batch summary.
+A failed adapter produces a failure result but does not reject or stop the
+other adapter runs.
+
+## Validation
+
+```powershell
+npx vitest run tests/adapter-reliability.test.ts
+npm run lint
+npm run build
+```

--- a/src/services/dnl/adapterError.ts
+++ b/src/services/dnl/adapterError.ts
@@ -1,0 +1,82 @@
+export type AdapterStage = "fetch" | "parse" | "normalize" | "ingest";
+
+export type AdapterErrorCode =
+  | "FETCH_FAILED"
+  | "INVALID_JSON"
+  | "INVALID_PAYLOAD"
+  | "NORMALIZATION_FAILED"
+  | "INGESTION_FAILED";
+
+export interface AdapterFailureDetails {
+  source: string;
+  stage: AdapterStage;
+  code: AdapterErrorCode;
+  message: string;
+  retryable: boolean;
+  occurredAt: string;
+}
+
+const safeMessage = (value: unknown): string => {
+  const message = value instanceof Error ? value.message : String(value);
+
+  return message
+    .replace(/https?:\/\/[^\s]+/gi, "[redacted-url]")
+    .replace(
+      /(?:api[_-]?key|token|secret|password)=?[^\s&]*/gi,
+      "$1=[redacted]",
+    )
+    .slice(0, 500);
+};
+
+export class AdapterError extends Error {
+  readonly source: string;
+  readonly stage: AdapterStage;
+  readonly code: AdapterErrorCode;
+  readonly retryable: boolean;
+
+  constructor(options: {
+    source: string;
+    stage: AdapterStage;
+    code: AdapterErrorCode;
+    message: string;
+    retryable?: boolean;
+    cause?: unknown;
+  }) {
+    super(options.message, { cause: options.cause });
+    this.name = "AdapterError";
+    this.source = options.source;
+    this.stage = options.stage;
+    this.code = options.code;
+    this.retryable = options.retryable ?? false;
+  }
+
+  toFailureDetails(): AdapterFailureDetails {
+    return {
+      source: this.source,
+      stage: this.stage,
+      code: this.code,
+      message: safeMessage(this.message),
+      retryable: this.retryable,
+      occurredAt: new Date().toISOString(),
+    };
+  }
+}
+
+export function toAdapterError(
+  source: string,
+  stage: AdapterStage,
+  error: unknown,
+  fallbackCode: AdapterErrorCode,
+  retryable = false,
+): AdapterError {
+  if (error instanceof AdapterError) return error;
+
+  return new AdapterError({
+    source,
+    stage,
+    code: fallbackCode,
+    message: safeMessage(error),
+    retryable,
+    cause: error,
+  });
+}

--- a/src/services/dnl/adapters/BaseOpportunityAdapter.ts
+++ b/src/services/dnl/adapters/BaseOpportunityAdapter.ts
@@ -1,0 +1,93 @@
+import { AdapterError, toAdapterError } from "../adapterError";
+import type { IOpportunityAdapter, NormalizedOpportunity } from "../types";
+
+export abstract class BaseOpportunityAdapter implements IOpportunityAdapter {
+  abstract readonly sourceName: string;
+
+  protected abstract normalizeItem(
+    item: Record<string, unknown>,
+    index: number,
+  ): NormalizedOpportunity;
+
+  normalize(rawPayload: unknown): NormalizedOpportunity[] {
+    const items = Array.isArray(rawPayload)
+      ? rawPayload
+      : rawPayload && typeof rawPayload === "object"
+        ? [rawPayload]
+        : [];
+
+    if (items.length === 0) {
+      throw new AdapterError({
+        source: this.sourceName,
+        stage: "normalize",
+        code: "INVALID_PAYLOAD",
+        message: "Adapter payload must contain at least one object.",
+      });
+    }
+
+    return items.map((item, index) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) {
+        throw new AdapterError({
+          source: this.sourceName,
+          stage: "normalize",
+          code: "INVALID_PAYLOAD",
+          message: `Payload item ${index} is not an object.`,
+        });
+      }
+
+      try {
+        const normalized = this.normalizeItem(
+          item as Record<string, unknown>,
+          index,
+        );
+
+        this.assertNormalized(normalized, index);
+        return normalized;
+      } catch (error) {
+        throw toAdapterError(
+          this.sourceName,
+          "normalize",
+          error,
+          "NORMALIZATION_FAILED",
+        );
+      }
+    });
+  }
+
+  private assertNormalized(
+    opportunity: NormalizedOpportunity,
+    index: number,
+  ): void {
+    if (!opportunity.title.trim()) {
+      throw new Error(`Payload item ${index} has no title.`);
+    }
+
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(opportunity.url);
+    } catch {
+      throw new Error(`Payload item ${index} has an invalid URL.`);
+    }
+
+    if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+      throw new Error(
+        `Payload item ${index} uses an unsupported URL protocol.`,
+      );
+    }
+  }
+
+  protected stringValue(value: unknown, fallback: string): string {
+    return typeof value === "string" && value.trim() ? value.trim() : fallback;
+  }
+
+  protected stringArray(value: unknown, fallback: string[]): string[] {
+    if (!Array.isArray(value)) return fallback;
+
+    const values = value
+      .filter((item): item is string => typeof item === "string")
+      .map((item) => item.trim())
+      .filter(Boolean);
+
+    return values.length > 0 ? values : fallback;
+  }
+}

--- a/src/services/dnl/adapters/DevpostAdapter.ts
+++ b/src/services/dnl/adapters/DevpostAdapter.ts
@@ -1,20 +1,28 @@
-import { IOpportunityAdapter, NormalizedOpportunity } from '../types';
+import type { NormalizedOpportunity } from "../types";
+import { BaseOpportunityAdapter } from "./BaseOpportunityAdapter";
 
-export class DevpostAdapter implements IOpportunityAdapter {
-  sourceName = 'Devpost';
+export class DevpostAdapter extends BaseOpportunityAdapter {
+  readonly sourceName = "Devpost";
 
-  normalize(rawPayload: any): NormalizedOpportunity[] {
-    const items = Array.isArray(rawPayload) ? rawPayload : [rawPayload];
-    return items.map((item) => ({
-      title: item.title || 'Untitled Opportunity',
-      company: item.organization || item.company || 'Unknown Organization',
-      description: item.description || 'No description provided.',
-      url: item.apply_link || item.url || 'https://devpost.com',
-      location: item.location || 'Online',
-      deadline: item.deadline || new Date().toISOString(),
-      tags: Array.isArray(item.tags) ? item.tags : ['Hackathon'],
-      opportunityType: item.opportunity_type || 'hackathon',
+  protected normalizeItem(
+    item: Record<string, unknown>,
+  ): NormalizedOpportunity {
+    return {
+      title: this.stringValue(item.title, "Untitled Opportunity"),
+      company: this.stringValue(
+        item.organization ?? item.company,
+        "Unknown Organization",
+      ),
+      description: this.stringValue(
+        item.description,
+        "No description provided.",
+      ),
+      url: this.stringValue(item.apply_link ?? item.url, "https://devpost.com"),
+      location: this.stringValue(item.location, "Online"),
+      deadline: this.stringValue(item.deadline, new Date().toISOString()),
+      tags: this.stringArray(item.tags, ["Hackathon"]),
+      opportunityType: this.stringValue(item.opportunity_type, "hackathon"),
       sourceName: this.sourceName,
-    }));
+    };
   }
 }

--- a/src/services/dnl/adapters/InternshalaAdapter.ts
+++ b/src/services/dnl/adapters/InternshalaAdapter.ts
@@ -1,24 +1,31 @@
-import { IOpportunityAdapter, NormalizedOpportunity } from '../types';
+import type { NormalizedOpportunity } from "../types";
+import { BaseOpportunityAdapter } from "./BaseOpportunityAdapter";
 
-export class InternshalaAdapter implements IOpportunityAdapter {
-  sourceName = 'Internshala';
+export class InternshalaAdapter extends BaseOpportunityAdapter {
+  readonly sourceName = "Internshala";
 
-  normalize(rawPayload: any): NormalizedOpportunity[] {
-    const items = Array.isArray(rawPayload) ? rawPayload : [rawPayload];
-    return items.map((item) => ({
-      title: item.title || 'Untitled Internship',
-      company: item.company || item.company_name || item.organization || 'Unknown Company',
-      description: item.description || item.details || 'No description provided.',
-      url: item.link || item.apply_link || item.url || 'https://internshala.com',
-      location: item.location || 'Remote',
-      deadline: item.deadline || new Date().toISOString(),
-      tags: Array.isArray(item.tags)
-        ? item.tags
-        : Array.isArray(item.skills_required)
-        ? item.skills_required
-        : ['Internship'],
-      opportunityType: item.opportunity_type || 'internship',
+  protected normalizeItem(
+    item: Record<string, unknown>,
+  ): NormalizedOpportunity {
+    return {
+      title: this.stringValue(item.title, "Untitled Internship"),
+      company: this.stringValue(
+        item.company ?? item.company_name ?? item.organization,
+        "Unknown Company",
+      ),
+      description: this.stringValue(
+        item.description ?? item.details,
+        "No description provided.",
+      ),
+      url: this.stringValue(
+        item.link ?? item.apply_link ?? item.url,
+        "https://internshala.com",
+      ),
+      location: this.stringValue(item.location, "Remote"),
+      deadline: this.stringValue(item.deadline, new Date().toISOString()),
+      tags: this.stringArray(item.tags ?? item.skills_required, ["Internship"]),
+      opportunityType: this.stringValue(item.opportunity_type, "internship"),
       sourceName: this.sourceName,
-    }));
+    };
   }
 }

--- a/src/services/dnl/scheduler.ts
+++ b/src/services/dnl/scheduler.ts
@@ -1,176 +1,285 @@
-import { IOpportunityAdapter } from './types';
-import { ingestOpportunities } from './deduplicator';
-import { logTelemetry } from './metrics';
-import { createBreaker } from '../circuitBreaker';
+import { createBreaker } from "../circuitBreaker";
+import { AdapterError, toAdapterError } from "./adapterError";
+import { ingestOpportunities } from "./deduplicator";
+import { logTelemetry } from "./metrics";
+import type {
+  AdapterBatchResult,
+  AdapterRunResult,
+  IOpportunityAdapter,
+} from "./types";
+
+type BreakerFetchResult = {
+  text: string;
+  ttfb: number;
+  fallbackError?: string;
+};
 
 export class DNLDispatcher {
-  private db: any;
-  private adapters: IOpportunityAdapter[] = [];
+  private readonly db: any;
+  private readonly adapters: IOpportunityAdapter[] = [];
   private intervalId: NodeJS.Timeout | null = null;
-  private breakers: Record<string, any> = {};
+  private readonly breakers: Record<string, any> = {};
 
   constructor(db: any) {
     this.db = db;
   }
 
-  registerAdapter(adapter: IOpportunityAdapter) {
+  registerAdapter(adapter: IOpportunityAdapter): void {
     this.adapters.push(adapter);
   }
 
   private getBreaker(sourceName: string) {
     if (!this.breakers[sourceName]) {
-      const fetchCb = async (url: string) => {
+      const fetchCb = async (url: string): Promise<BreakerFetchResult> => {
         const fetchStart = performance.now();
         const response = await fetch(url);
+
         if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
+          throw new Error(
+            `HTTP request failed with status ${response.status}.`,
+          );
         }
-        
-        let ttfb = 0;
-        // In Node.js environment, response.body might not have getReader if it's node-fetch.
-        // We'll do a simple fallback if reader is not available.
-        if (response.body && typeof (response.body as any).getReader === 'function') {
-          const reader = (response.body as any).getReader();
-          await reader.read();
-          ttfb = Math.round(performance.now() - fetchStart);
-        } else {
-          ttfb = Math.round(performance.now() - fetchStart);
-        }
-        
+
         const text = await response.text();
-        return { text, ttfb };
+        return {
+          text,
+          ttfb: Math.round(performance.now() - fetchStart),
+        };
       };
-      
+
       const breaker = createBreaker(
         fetchCb,
-        { timeout: 10000, errorThresholdPercentage: 50, resetTimeout: 30000 },
-        sourceName
+        {
+          timeout: 10_000,
+          errorThresholdPercentage: 50,
+          resetTimeout: 30_000,
+        },
+        sourceName,
       );
-      
-      breaker.fallback((url, err) => {
-        // Return empty payload array if circuit opens or fetch fails
-        return { text: "[]", ttfb: 0 };
-      });
+
+      breaker.fallback((_url: string, error: unknown) => ({
+        text: "[]",
+        ttfb: 0,
+        fallbackError:
+          error instanceof Error
+            ? error.message
+            : "Circuit breaker fallback used.",
+      }));
 
       this.breakers[sourceName] = breaker;
     }
+
     return this.breakers[sourceName];
   }
 
-  // Orchestrate a single run for an adapter with its payload/url
-  async runScrape(adapter: IOpportunityAdapter, fetchUrlOrPayload: string | any[]): Promise<void> {
+  async runScrape(
+    adapter: IOpportunityAdapter,
+    fetchUrlOrPayload: string | unknown[],
+  ): Promise<AdapterRunResult> {
     const startTime = performance.now();
     let ttfb = 0;
-    let rawPayload: any = null;
-    let errorStack: string | null = null;
-    let status: 'healthy' | 'degraded' | 'failed' = 'healthy';
 
     try {
-      if (typeof fetchUrlOrPayload === 'string') {
-        const breaker = this.getBreaker(adapter.sourceName);
-        const result = await breaker.fire(fetchUrlOrPayload);
+      let rawPayload: unknown;
+
+      if (typeof fetchUrlOrPayload === "string") {
+        const result = (await this.getBreaker(adapter.sourceName).fire(
+          fetchUrlOrPayload,
+        )) as BreakerFetchResult;
+
         ttfb = result.ttfb;
-        rawPayload = JSON.parse(result.text);
+
+        if (result.fallbackError) {
+          throw new AdapterError({
+            source: adapter.sourceName,
+            stage: "fetch",
+            code: "FETCH_FAILED",
+            message: result.fallbackError,
+            retryable: true,
+          });
+        }
+
+        try {
+          rawPayload = JSON.parse(result.text);
+        } catch (error) {
+          throw new AdapterError({
+            source: adapter.sourceName,
+            stage: "parse",
+            code: "INVALID_JSON",
+            message: "Adapter endpoint returned invalid JSON.",
+            retryable: true,
+            cause: error,
+          });
+        }
       } else {
-        // Static/mock payload
-        const simulatedDelay = Math.floor(Math.random() * 50) + 10; // 10ms-60ms
-        await new Promise((resolve) => setTimeout(resolve, simulatedDelay));
-        ttfb = simulatedDelay;
         rawPayload = fetchUrlOrPayload;
       }
 
-      // 2. Normalization
       const normalized = adapter.normalize(rawPayload);
-
-      // 3. Deduplication & Database Ingestion
-      const result = await ingestOpportunities(this.db, normalized);
-
-      const durationSec = (performance.now() - startTime) / 1000;
-
-      if (result.failures > 0) {
-        status = 'degraded';
-      }
+      const ingestion = await ingestOpportunities(this.db, normalized);
+      const durationMs = Math.round(performance.now() - startTime);
+      const status = ingestion.failures > 0 ? "degraded" : "healthy";
 
       await logTelemetry(this.db, {
-        id: adapter.sourceName.toLowerCase().replace(/[^a-z0-9]/g, '_'),
+        id: this.telemetryId(adapter.sourceName),
         name: adapter.sourceName,
         status,
         lastRun: new Date().toISOString(),
         ttfb_ms: ttfb,
-        payloads_processed: result.processed,
-        inserted: result.inserted,
-        duplicates: result.duplicates,
-        failures: result.failures,
-        duration_sec: parseFloat(durationSec.toFixed(3)),
-        error: result.errors.length > 0 ? result.errors.join('\n') : null,
-        yield_quality: result.processed > 0 ? Math.round(((result.processed - result.failures) / result.processed) * 100) : 100,
-        ops_per_hour: Math.round((result.inserted / durationSec) * 3600) || 0,
-        proxyHealth: 'green'
+        payloads_processed: ingestion.processed,
+        inserted: ingestion.inserted,
+        duplicates: ingestion.duplicates,
+        failures: ingestion.failures,
+        duration_sec: durationMs / 1000,
+        error:
+          ingestion.errors.length > 0
+            ? ingestion.errors.join("\n").slice(0, 2000)
+            : null,
+        error_code: ingestion.failures > 0 ? "INGESTION_FAILED" : null,
+        error_stage: ingestion.failures > 0 ? "ingest" : null,
+        retryable: ingestion.failures > 0,
+        yield_quality:
+          ingestion.processed > 0
+            ? Math.round(
+                ((ingestion.processed - ingestion.failures) /
+                  ingestion.processed) *
+                  100,
+              )
+            : 100,
+        ops_per_hour:
+          durationMs > 0
+            ? Math.round((ingestion.inserted / durationMs) * 3_600_000)
+            : 0,
+        proxyHealth: status === "healthy" ? "green" : "yellow",
       });
-    } catch (err: any) {
-      const durationSec = (performance.now() - startTime) / 1000;
-      errorStack = err.stack || err.message || String(err);
-      
+
+      return {
+        source: adapter.sourceName,
+        success: true,
+        status,
+        processed: ingestion.processed,
+        inserted: ingestion.inserted,
+        duplicates: ingestion.duplicates,
+        failures: ingestion.failures,
+        durationMs,
+      };
+    } catch (error) {
+      const adapterError = toAdapterError(
+        adapter.sourceName,
+        "normalize",
+        error,
+        "NORMALIZATION_FAILED",
+      );
+      const failure = adapterError.toFailureDetails();
+      const durationMs = Math.round(performance.now() - startTime);
+
       await logTelemetry(this.db, {
-        id: adapter.sourceName.toLowerCase().replace(/[^a-z0-9]/g, '_'),
+        id: this.telemetryId(adapter.sourceName),
         name: adapter.sourceName,
-        status: 'failed',
+        status: "failed",
         lastRun: new Date().toISOString(),
         ttfb_ms: ttfb,
         payloads_processed: 0,
         inserted: 0,
         duplicates: 0,
         failures: 1,
-        duration_sec: parseFloat(durationSec.toFixed(3)),
-        error: errorStack,
+        duration_sec: durationMs / 1000,
+        error: failure.message,
+        error_code: failure.code,
+        error_stage: failure.stage,
+        retryable: failure.retryable,
         yield_quality: 0,
         ops_per_hour: 0,
-        proxyHealth: 'red'
+        proxyHealth: "red",
       });
-      console.error(`[DNLDispatcher] Run failed for ${adapter.sourceName}:`, err);
+
+      console.error(
+        `[DNLDispatcher] ${failure.source} failed during ${failure.stage} (${failure.code}): ${failure.message}`,
+      );
+
+      return {
+        source: adapter.sourceName,
+        success: false,
+        status: "failed",
+        processed: 0,
+        inserted: 0,
+        duplicates: 0,
+        failures: 1,
+        durationMs,
+        failure,
+      };
     }
   }
 
-  // Start periodic scraping runs (cron-job dispatcher)
-  start(intervalMs: number = 3600000) {
+  async runAdapters(
+    tasks: Array<{
+      adapter: IOpportunityAdapter;
+      input: string | unknown[];
+    }>,
+  ): Promise<AdapterBatchResult> {
+    const settled = await Promise.all(
+      tasks.map(({ adapter, input }) => this.runScrape(adapter, input)),
+    );
+
+    return {
+      total: settled.length,
+      succeeded: settled.filter((result) => result.success).length,
+      failed: settled.filter((result) => !result.success).length,
+      results: settled,
+    };
+  }
+
+  start(intervalMs = 3_600_000): void {
     if (this.intervalId) return;
-    
-    console.log(`[DNLDispatcher] Scheduler started. Dispatching runs every ${intervalMs / 1000}s.`);
+
+    console.log(
+      `[DNLDispatcher] Scheduler started. Dispatching every ${intervalMs / 1000}s.`,
+    );
+
     this.intervalId = setInterval(() => {
-      this.dispatchAll();
+      void this.dispatchAll();
     }, intervalMs);
   }
 
-  stop() {
-    if (this.intervalId) {
-      clearInterval(this.intervalId);
-      this.intervalId = null;
-      console.log('[DNLDispatcher] Scheduler stopped.');
+  stop(): void {
+    if (!this.intervalId) return;
+
+    clearInterval(this.intervalId);
+    this.intervalId = null;
+    console.log("[DNLDispatcher] Scheduler stopped.");
+  }
+
+  private async dispatchAll(): Promise<void> {
+    const tasks = this.adapters.flatMap((adapter) => {
+      const environmentKey = `SCRAPER_URL_${adapter.sourceName
+        .toUpperCase()
+        .replace(/[^A-Z0-9]/g, "_")}`;
+      const configuredUrl = process.env[environmentKey];
+
+      if (!configuredUrl) {
+        console.warn(
+          `[DNLDispatcher] ${environmentKey} is not configured. Skipping ${adapter.sourceName}.`,
+        );
+        return [];
+      }
+
+      return [{ adapter, input: configuredUrl }];
+    });
+
+    const summary = await this.runAdapters(tasks);
+
+    if (summary.failed > 0) {
+      console.error(
+        `[DNLDispatcher] Completed with ${summary.failed}/${summary.total} adapter failure(s).`,
+      );
+    } else {
+      console.log(
+        `[DNLDispatcher] All ${summary.succeeded} configured adapter run(s) completed.`,
+      );
     }
   }
 
-  private async dispatchAll() {
-    console.log(`[DNLDispatcher] Cron trigger: Dispatching ${this.adapters.length} scraper run(s)...`);
-
-    const results = await Promise.allSettled(
-      this.adapters.map(async (adapter) => {
-        const sourceName = adapter.sourceName;
-        const configUrl = process.env[`SCRAPER_URL_${sourceName.toUpperCase()}`];
-
-        if (configUrl) {
-          console.log(`[DNLDispatcher] Running scraper for ${sourceName} via URL: ${configUrl}`);
-          await this.runScrape(adapter, configUrl);
-        } else {
-          console.warn(`[DNLDispatcher] No SCRAPER_URL_${sourceName.toUpperCase()} configured. Skipping ${sourceName}.`);
-        }
-      })
-    );
-
-    const failed = results.filter(r => r.status === 'rejected').length;
-    if (failed > 0) {
-      console.error(`[DNLDispatcher] ${failed}/${this.adapters.length} scraper run(s) failed.`);
-    } else {
-      console.log(`[DNLDispatcher] All ${this.adapters.length} scraper run(s) completed.`);
-    }
+  private telemetryId(sourceName: string): string {
+    return sourceName.toLowerCase().replace(/[^a-z0-9]/g, "_");
   }
 }

--- a/src/services/dnl/types.ts
+++ b/src/services/dnl/types.ts
@@ -1,10 +1,12 @@
+import type { AdapterFailureDetails } from "./adapterError";
+
 export interface NormalizedOpportunity {
   title: string;
   company: string;
   description: string;
   url: string;
   location: string;
-  deadline: string; // ISO format or text
+  deadline: string;
   tags: string[];
   opportunityType: string;
   sourceName: string;
@@ -12,22 +14,44 @@ export interface NormalizedOpportunity {
 
 export interface IOpportunityAdapter {
   sourceName: string;
-  normalize(rawPayload: any): NormalizedOpportunity[];
+  normalize(rawPayload: unknown): NormalizedOpportunity[];
+}
+
+export interface AdapterRunResult {
+  source: string;
+  success: boolean;
+  status: "healthy" | "degraded" | "failed";
+  processed: number;
+  inserted: number;
+  duplicates: number;
+  failures: number;
+  durationMs: number;
+  failure?: AdapterFailureDetails;
+}
+
+export interface AdapterBatchResult {
+  total: number;
+  succeeded: number;
+  failed: number;
+  results: AdapterRunResult[];
 }
 
 export interface ScraperMetrics {
-  id: string; // e.g. "devpost"
-  name: string; // e.g. "Devpost"
-  status: 'healthy' | 'degraded' | 'failed';
-  lastRun: string; // ISO timestamp
-  ttfb_ms: number; // Time To First Byte in milliseconds
+  id: string;
+  name: string;
+  status: "healthy" | "degraded" | "failed";
+  lastRun: string;
+  ttfb_ms: number;
   payloads_processed: number;
   inserted: number;
   duplicates: number;
   failures: number;
   duration_sec: number;
-  error: string | null; // Raw stack trace if failed, else null
+  error: string | null;
+  error_code?: string | null;
+  error_stage?: string | null;
+  retryable?: boolean;
   yield_quality: number;
   ops_per_hour: number;
-  proxyHealth: 'green' | 'yellow' | 'red';
+  proxyHealth: "green" | "yellow" | "red";
 }

--- a/tests/adapter-reliability.test.ts
+++ b/tests/adapter-reliability.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/services/dnl/deduplicator", () => ({
+  ingestOpportunities: vi.fn(async (_db, opportunities) => ({
+    processed: opportunities.length,
+    inserted: opportunities.length,
+    duplicates: 0,
+    failures: 0,
+    errors: [],
+  })),
+}));
+
+vi.mock("../src/services/dnl/metrics", () => ({
+  logTelemetry: vi.fn(async () => undefined),
+}));
+
+import { AdapterError } from "../src/services/dnl/adapterError";
+import { DevpostAdapter } from "../src/services/dnl/adapters/DevpostAdapter";
+import { InternshalaAdapter } from "../src/services/dnl/adapters/InternshalaAdapter";
+import { DNLDispatcher } from "../src/services/dnl/scheduler";
+import type {
+  IOpportunityAdapter,
+  NormalizedOpportunity,
+} from "../src/services/dnl/types";
+import { logTelemetry } from "../src/services/dnl/metrics";
+
+const mockedLogTelemetry = vi.mocked(logTelemetry);
+
+describe("DNL adapter reliability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("normalizes valid Devpost and Internshala payloads", () => {
+    expect(
+      new DevpostAdapter().normalize({
+        title: "Build Challenge",
+        organization: "Example",
+        apply_link: "https://example.test/apply",
+      }),
+    ).toHaveLength(1);
+
+    expect(
+      new InternshalaAdapter().normalize({
+        title: "Backend Internship",
+        company: "Example",
+        link: "https://example.test/internship",
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("returns a structured adapter error for invalid payloads", () => {
+    expect(() => new DevpostAdapter().normalize([])).toThrow(AdapterError);
+
+    try {
+      new DevpostAdapter().normalize([]);
+    } catch (error) {
+      const failure = (error as AdapterError).toFailureDetails();
+      expect(failure).toEqual(
+        expect.objectContaining({
+          source: "Devpost",
+          stage: "normalize",
+          code: "INVALID_PAYLOAD",
+          retryable: false,
+        }),
+      );
+    }
+  });
+
+  it("keeps successful adapters running when another adapter fails", async () => {
+    const failingAdapter: IOpportunityAdapter = {
+      sourceName: "BrokenPlatform",
+      normalize(): NormalizedOpportunity[] {
+        throw new Error("selector no longer matches");
+      },
+    };
+
+    const dispatcher = new DNLDispatcher({});
+    const summary = await dispatcher.runAdapters([
+      {
+        adapter: failingAdapter,
+        input: [{ unexpected: true }],
+      },
+      {
+        adapter: new DevpostAdapter(),
+        input: [
+          {
+            title: "Working Opportunity",
+            organization: "Example",
+            apply_link: "https://example.test/apply",
+          },
+        ],
+      },
+    ]);
+
+    expect(summary.total).toBe(2);
+    expect(summary.failed).toBe(1);
+    expect(summary.succeeded).toBe(1);
+    expect(summary.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "BrokenPlatform",
+          success: false,
+          status: "failed",
+        }),
+        expect.objectContaining({
+          source: "Devpost",
+          success: true,
+          status: "healthy",
+        }),
+      ]),
+    );
+
+    expect(mockedLogTelemetry).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        name: "BrokenPlatform",
+        status: "failed",
+        error_code: "NORMALIZATION_FAILED",
+        error_stage: "normalize",
+      }),
+    );
+  });
+
+  it("redacts URLs and secrets from failure details", () => {
+    const error = new AdapterError({
+      source: "Example",
+      stage: "fetch",
+      code: "FETCH_FAILED",
+      message:
+        "Failed https://example.test/path?api_key=secret-value token=abc123",
+      retryable: true,
+    });
+
+    const failure = error.toFailureDetails();
+    expect(failure.message).not.toContain("secret-value");
+    expect(failure.message).not.toContain("abc123");
+    expect(failure.message).not.toContain("https://example.test");
+  });
+});


### PR DESCRIPTION
## Description

Improves opportunity adapter reliability with structured error reporting, source-level telemetry, circuit-breaker failure detection, and adapter isolation.

Fixes #392

## Repository mapping

The issue refers to older adapter files such as:

```text
baseAdapter.ts
internshalaAdapter.ts
linkedinAdapter.ts
unstopAdapter.ts
```

The current YuvaHub architecture implements this functionality under:

```text
src/services/dnl/adapters/
src/services/dnl/scheduler.ts
```

This PR applies the issue requirements to the current architecture rather than introducing duplicate legacy adapters.

## Changes

### Shared adapter base

* Added `BaseOpportunityAdapter`
* Added common payload validation
* Added normalised URL validation
* Added safe string and string-array extraction
* Added consistent invalid-payload behaviour
* Reduced duplicated adapter normalisation logic

### Structured errors

Added adapter failure metadata containing:

* Source
* Failure stage
* Stable error code
* Safe error message
* Retryability
* Timestamp

Supported failure codes include:

```text
FETCH_FAILED
INVALID_JSON
INVALID_PAYLOAD
NORMALIZATION_FAILED
INGESTION_FAILED
```

### Circuit-breaker reliability

The previous circuit-breaker fallback returned an empty array payload.

This could cause a failed upstream request to be reported as a healthy run with zero results.

The fallback now carries an explicit failure marker and is recorded as:

```text
stage: fetch
code: FETCH_FAILED
retryable: true
status: failed
```

### Adapter isolation

Added a `runAdapters()` batch method that:

* Executes all adapter tasks independently
* Returns successful results even when another adapter fails
* Provides succeeded and failed counts
* Does not abort the complete batch after one adapter error

### Telemetry

Added structured telemetry fields:

```text
error_code
error_stage
retryable
```

Adapter errors are now visible at the source level without requiring raw stack traces.

### Error safety

Error details are sanitised before logging and reporting.

The implementation redacts:

* Full URLs
* API key values
* Tokens
* Secrets
* Password-like values

### Tests

Added tests for:

* Devpost normalisation
* Internshala normalisation
* Empty-payload rejection
* Structured error information
* Adapter failure isolation
* Successful adapter continuation
* Failure telemetry
* URL and credential redaction

## Validation

* [ ] Adapter reliability tests passed
* [ ] TypeScript validation passed
* [ ] Production build passed
* [ ] Devpost normalisation works
* [ ] Internshala normalisation works
* [ ] Invalid payloads return structured errors
* [ ] Fetch failures are no longer reported as healthy
* [ ] One adapter failure does not stop other adapters
* [ ] Failure telemetry contains source and stage
* [ ] Retryable failures are identified
* [ ] URLs are removed from failure messages
* [ ] Credential-like values are redacted
* [ ] Existing DNL ingestion behaviour remains functional

## Test commands

```bash
npx vitest run tests/adapter-reliability.test.ts
npm run lint
npm run build
```

## Testing evidence
<img width="1323" height="474" alt="Screenshot 2026-07-28 233037" src="https://github.com/user-attachments/assets/70832ce9-f627-43fb-98da-8f3460ae96ed" />
