### PR TITLE
fix: add fail-fast JWT secret validation at server startup to prevent token forgery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# =========================================================================
+﻿# =========================================================================
 # YUVAHUB - ENVIRONMENT CONFIGURATION TEMPLATE
 # Copy this file to '.env' and fill in the values for local development.
 # =========================================================================
@@ -17,7 +17,7 @@ MONGODB_DB_NAME=yuvahub
 # -------------------------------------------------------------------------
 # Google Gemini AI API Configuration
 # -------------------------------------------------------------------------
-# SERVER-ONLY SECRET — never prefix with VITE_ and never access from browser code.
+# SERVER-ONLY SECRET â€” never prefix with VITE_ and never access from browser code.
 # Used only by the Express API, workers, and server-side Gemini services.
 # All frontend AI requests must go through /api/v1/ai/* backend routes.
 # Rotate any key that may previously have appeared in a deployed client bundle.
@@ -116,6 +116,7 @@ VITE_ADMIN_EMAILS=admin1@example.com,admin2@example.com
 # JWT Secret Configuration
 # -------------------------------------------------------------------------
 JWT_SECRET=your_jwt_secret_key_here
+JWT_REFRESH_SECRET=your_jwt_refresh_secret_key_here
 
 # -------------------------------------------------------------------------
 # Sentry APM Configuration (Optional)

--- a/server.ts
+++ b/server.ts
@@ -21,6 +21,25 @@ import { createOpportunityScrapedConsumer } from "./src/consumers/opportunityScr
 
 dotenv.config();
 
+// ---------------------------------------------------------------------------
+// JWT Secret Validation — fail fast in production
+// ---------------------------------------------------------------------------
+const { JWT_SECRET, JWT_REFRESH_SECRET, NODE_ENV } = process.env;
+
+if (NODE_ENV === 'production') {
+  const MISSING: string[] = [];
+  if (!JWT_SECRET) MISSING.push('JWT_SECRET');
+  if (!JWT_REFRESH_SECRET) MISSING.push('JWT_REFRESH_SECRET');
+
+  if (MISSING.length > 0) {
+    console.error(`[FATAL] ${MISSING.join(' and ')} must be explicitly set in production mode.`);
+    process.exit(1);
+  }
+} else {
+  if (!JWT_SECRET) console.warn('[WARN] JWT_SECRET not set. Using auto-generated secrets for development only.');
+  if (!JWT_REFRESH_SECRET) console.warn('[WARN] JWT_REFRESH_SECRET not set. Using auto-generated secrets for development only.');
+}
+
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Summary

Add fail-fast JWT secret validation at server startup. In production, the server now exits immediately with an explicit configuration error if `JWT_SECRET` or `JWT_REFRESH_SECRET` environment variables are missing, preventing silent token forgery.

---

## 🔗 Related Issue

Closes #501

---

## ✨ Changes Made

- Added startup validation in `server.ts` that fails fast (`process.exit(1)`) in production when JWT secrets are unset
- Emits high-priority `[WARN]` logs in development mode when JWT secrets are missing
- Added `JWT_REFRESH_SECRET` configuration entry to `.env.example` (was missing)

---

## 🧪 Testing

- [x] Tested locally
- [ ] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)

---

## 📸 Screenshots

N/A

---

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [x] I have updated the documentation (if required).
- [ ] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

❤️ Thank you for contributing!