### PR TITLE
fix: escape XML special characters in /sitemap.xml to prevent malformed output

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -90,6 +90,22 @@ app.get("/robots.txt", (req: Request, res: Response) => {
   res.send(robotsTxt);
 });
 
+// ---------------------------------------------------------------------------
+// XML escaping helper for safe sitemap generation
+// ---------------------------------------------------------------------------
+function escapeXml(unsafe: string): string {
+  return unsafe.replace(/[<>&'"]/g, (c) => {
+    switch (c) {
+      case "<": return "&lt;";
+      case ">": return "&gt;";
+      case "&": return "&amp;";
+      case "'": return "&apos;";
+      case '"': return "&quot;";
+      default: return c;
+    }
+  });
+}
+
 app.get("/sitemap.xml", async (req: Request, res: Response) => {
   try {
     const baseUrl = process.env.APP_URL || "https://yuvahub.xyz";
@@ -106,9 +122,10 @@ app.get("/sitemap.xml", async (req: Request, res: Response) => {
       "/legal",
     ];
 
+    const escapedBaseUrl = escapeXml(baseUrl);
     let urls = staticPaths.map((p) => {
       return `  <url>
-    <loc>${baseUrl}${p}</loc>
+    <loc>${escapedBaseUrl}${p}</loc>
     <changefreq>daily</changefreq>
     <priority>${p === "" ? "1.0" : "0.8"}</priority>
   </url>`;
@@ -124,17 +141,17 @@ app.get("/sitemap.xml", async (req: Request, res: Response) => {
           .toArray();
 
         const oppUrls = items.map((item: Record<string, any>) => {
-          const id = item._id ? item._id.toString() : item.id;
+          const id = escapeXml(item._id ? item._id.toString() : item.id);
           const title = item.title || "opportunity";
           const cleanTitle = title
             .toLowerCase()
             .replace(/[^a-z0-9]+/g, "-")
             .replace(/^-+|-+$/g, "");
-          const lastmod = item.created_at
+          const lastmod = escapeXml(item.created_at
             ? new Date(item.created_at).toISOString().split("T")[0]
-            : new Date().toISOString().split("T")[0];
+            : new Date().toISOString().split("T")[0]);
           return `  <url>
-    <loc>${baseUrl}/opportunity/${id}/${cleanTitle}</loc>
+    <loc>${escapedBaseUrl}/opportunity/${id}/${cleanTitle}</loc>
     <lastmod>${lastmod}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Summary

Add XML escaping to all dynamic values in `/sitemap.xml` to prevent malformed XML output when opportunity titles or other fields contain special characters like `&`, `<`, `>`, `'`, or `"`.

---

## 🔗 Related Issue

Closes #502

---

## ✨ Changes Made

- Added `escapeXml()` helper function that encodes the five XML special characters (`&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`, `'` → `&apos;`, `"` → `&quot;`)
- Applied `escapeXml()` to all dynamic values (`baseUrl`, `id`, `lastmod`) rendered inside `/sitemap.xml`
- Pre-computed `escapedBaseUrl` for reuse across static and dynamic URL entries

---

## 🧪 Testing

- [x] Tested locally
- [ ] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)

---

## 📸 Screenshots

N/A

---

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [ ] I have updated the documentation (if required).
- [ ] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

❤️ Thank you for contributing!