### PR TITLE
fix: support MongoDB query operators in MemoryCollection findSync

### DIFF
--- a/src/api/db.ts
+++ b/src/api/db.ts
@@ -128,8 +128,55 @@ export class MemoryCollection {
           });
         });
       } else {
-        // Generic key-value match
-        result = result.filter(r => r[key] === query[key]);
+        // Generic key-value match with MongoDB operator support
+        result = result.filter(r => {
+          const condition = query[key];
+          const itemValue = r[key];
+
+          // Handle operator objects like { $in: [...], $gte: ..., etc. }
+          if (condition && typeof condition === 'object' && !Array.isArray(condition)) {
+            // All specified operators must match (AND logic)
+            if ('$in' in condition) {
+              if (!Array.isArray(condition.$in)) return false;
+              if (!condition.$in.some((v: any) =>
+                itemValue === v || itemValue?.toString() === v?.toString()
+              )) return false;
+            }
+            if ('$nin' in condition) {
+              if (!Array.isArray(condition.$nin)) return false;
+              if (condition.$nin.some((v: any) =>
+                itemValue === v || itemValue?.toString() === v?.toString()
+              )) return false;
+            }
+            if ('$gte' in condition) {
+              if (!(itemValue >= condition.$gte)) return false;
+            }
+            if ('$lte' in condition) {
+              if (!(itemValue <= condition.$lte)) return false;
+            }
+            if ('$gt' in condition) {
+              if (!(itemValue > condition.$gt)) return false;
+            }
+            if ('$lt' in condition) {
+              if (!(itemValue < condition.$lt)) return false;
+            }
+            if ('$ne' in condition) {
+              if (itemValue === condition.$ne || itemValue?.toString() === condition.$ne?.toString()) return false;
+            }
+            if ('$regex' in condition) {
+              try {
+                const regex = new RegExp(condition.$regex, condition.$options || '');
+                if (!regex.test(String(itemValue))) return false;
+              } catch {
+                return false;
+              }
+            }
+            return true;
+          }
+
+          // Simple equality fallback
+          return itemValue === condition;
+        });
       }
     }
     return result;


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Summary

Enhance `MemoryCollection.findSync()` to evaluate MongoDB query operators (`$in`, `$nin`, `$gte`, `$lte`, `$gt`, `$lt`, `$ne`, `$regex`) so the offline mock database fallback mirrors real MongoDB query behavior.

---

## 🔗 Related Issue

Closes #504

---

## ✨ Changes Made

- Replaced the simple equality check in `MemoryCollection.findSync` generic key-value branch with operator-aware matching
- Added support for `$in`, `$nin`, `$gte`, `$lte`, `$gt`, `$lt`, `$ne`, and `$regex` query operators
- Multiple operators on the same field use AND logic (matching MongoDB behavior)
- Simple equality still works as fallback for non-operator queries

---

## 🧪 Testing

- [x] Tested locally
- [ ] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)

---

## 📸 Screenshots

N/A

---

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [ ] I have updated the documentation (if required).
- [ ] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

❤️ Thank you for contributing!