### PR TITLE
fix: standardize dedupe hash field to dedupe_hash across scraper worker

### DIFF
--- a/src/workers/scraperWorker.ts
+++ b/src/workers/scraperWorker.ts
@@ -46,7 +46,7 @@ export const scraperWorker = new Worker(
       opportunityType: type,
       deadline: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(), // 30 days from now
       location: "Online",
-      dedupeHash,
+      dedupe_hash: dedupeHash,
       createdAt: new Date().toISOString(),
       embedding: null as number[] | null,
     };
@@ -57,7 +57,7 @@ export const scraperWorker = new Worker(
     // Upsert into MongoDB for idempotency
     const db = mongoClient.db(dbName);
     const result = await db.collection("opportunities").updateOne(
-      { dedupeHash: opportunity.dedupeHash },
+      { dedupe_hash: opportunity.dedupe_hash },
       { $set: opportunity },
       { upsert: true }
     );
@@ -68,7 +68,7 @@ export const scraperWorker = new Worker(
       console.log(`[ScraperWorker] Updated existing opportunity: ${title}`);
     }
 
-    return { status: "success", dedupeHash: opportunity.dedupeHash };
+    return { status: "success", dedupe_hash: opportunity.dedupe_hash };
   },
   {
     connection: connection as any,


### PR DESCRIPTION
## Description

This PR fixes a critical data integrity bug where the deduplication hash field name is inconsistent across the codebase. The scraper worker wrote and queried using `dedupeHash` (camelCase), while the opportunity scraped consumer, user-submit controller, and DNL unique index all use `dedupe_hash` (snake_case).

This meant the scraper worker's upsert query `{ dedupeHash: ... }` never matched documents written by other pipelines (which store `dedupe_hash`). Each code path created separate documents for the same opportunity, and the DNL unique index could not catch duplicates from the scraper worker.

This PR standardizes the scraper worker to use `dedupe_hash`, matching the database index and all other components.

---

## Related Issue

* Closes #494

---

## Component(s) Affected

* [x] Backend (`server/`)
* [ ] Mobile app (`rhythma_flutter/`)
* [ ] Web app (`web/`)
* [ ] Landing page (`landing-page/`)
* [ ] Docs only (README, CONTRIBUTING, architecture, etc.)
* [ ] CI / tooling

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor (no behavior change)
* [ ] Tests
* [ ] Other:

---

## Testing Performed

### Commands executed

* [ ] `npm test`
* [x] `npm run lint`
* [x] `npm run build`
* [x] Manual verification

### Manually verified

* Changed all 3 references in scraperWorker.ts: object field, upsert query key, and return value.
* Confirmed opportunityScrapedConsumer.ts already uses `dedupe_hash`.
* Confirmed opportunityController.ts (line 414) already uses `dedupe_hash`.
* Confirmed DNL metrics.ts index is on `dedupe_hash`.
* Verified TypeScript compilation passes with no new errors.

---

## API Documentation (required for any new/changed backend endpoint)

Not applicable — internal field name change only.

---

## Documentation Updates

* [x] Not applicable

---

## Checklist

* [x] I have read `CONTRIBUTING.md`
* [ ] I rebased/merged the latest `main` into this branch
* [x] I tested my changes locally (see Testing Performed above)
* [x] This PR is scoped to one logical change
* [x] I did not commit any secrets, credentials, or real `.env` files
