### PR TITLE
fix: JIT user upsert missing uid field breaks downstream lookups

### DIFF
--- a/src/api/db.ts
+++ b/src/api/db.ts
@@ -170,6 +170,41 @@ export class MemoryCollection {
     }
     return { modifiedCount: 0 };
   }
+  async findOneAndUpdate(filter: any, update: any, options: any = {}) {
+    const item = await this.findOne(filter);
+    if (item) {
+      if (update.$set) Object.assign(item, update.$set);
+      if (update.$setOnInsert) Object.assign(item, update.$setOnInsert);
+      if (update.$push) {
+        for (const key in update.$push) {
+          if (!Array.isArray(item[key])) item[key] = [];
+          item[key].push(update.$push[key]);
+        }
+      }
+      if (update.$addToSet) {
+        for (const key in update.$addToSet) {
+          if (!Array.isArray(item[key])) item[key] = [];
+          if (!item[key].includes(update.$addToSet[key])) item[key].push(update.$addToSet[key]);
+        }
+      }
+      if (update.$pull) {
+        for (const key in update.$pull) {
+          if (Array.isArray(item[key])) {
+            item[key] = item[key].filter((x: any) => x !== update.$pull[key]);
+          }
+        }
+      }
+      return { value: item, ok: 1 };
+    }
+    if (options.upsert) {
+      const doc = { ...filter };
+      if (update.$set) Object.assign(doc, update.$set);
+      if (update.$setOnInsert) Object.assign(doc, update.$setOnInsert);
+      this.data.push(doc);
+      return { value: doc, ok: 1 };
+    }
+    return { value: null, ok: 0 };
+  }
   async insertOne(doc: any) { this.data.push(doc); return { insertedId: "mock_id" }; }
   async deleteOne(query: any) {
     const initialLen = this.data.length;

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -106,6 +106,7 @@ export const authenticateUser = (dbCommand: any) => {
             { firebaseUid: decodedToken.uid },
             {
               $setOnInsert: {
+                uid: decodedToken.uid,
                 firebaseUid: decodedToken.uid,
                 email: decodedToken.email,
                 name: decodedToken.name || '',


### PR DESCRIPTION
## Description

This PR fixes a data integrity bug where the JIT (Just-In-Time) user upsert in the auth middleware created user documents without the `uid` field. The `$setOnInsert` block populated `firebaseUid` but omitted `uid`, causing downstream lookups by `uid` to return `null`.

Affected paths:
- `resumeWorker.ts` — querying `{ uid: userId }` fails, resume processing silently doesn't update user profiles
- `authController.ts` `authSync` — querying `{ uid }` returns null, profile sync does nothing
- Additionally, `MemoryCollection` (MockDB mode) lacked a `findOneAndUpdate` implementation entirely, throwing a runtime error in development

This PR adds `uid` to the `$setOnInsert` block and implements a full `findOneAndUpdate` shim on `MemoryCollection` supporting `$set`, `$setOnInsert`, `$push`, `$addToSet`, `$pull`, and upsert.

---

## Related Issue

* Closes #495

---

## Component(s) Affected

* [x] Backend (`server/`)
* [ ] Mobile app (`rhythma_flutter/`)
* [ ] Web app (`web/`)
* [ ] Landing page (`landing-page/`)
* [ ] Docs only (README, CONTRIBUTING, architecture, etc.)
* [ ] CI / tooling

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor (no behavior change)
* [ ] Tests
* [ ] Other:

---

## Testing Performed

### Commands executed

* [ ] `npm test`
* [x] `npm run lint`
* [x] `npm run build`
* [x] Manual verification

### Manually verified

* Added `uid: decodedToken.uid` to `$setOnInsert` in auth.ts.
* Implemented `findOneAndUpdate` on `MemoryCollection` with full operator support.
* Verified `findOneAndUpdate` returns `{ value }` shape matching the MongoDB driver.
* Verified upsert path creates a new document with both filter and `$setOnInsert` fields.
* Verified TypeScript compilation passes with no new errors.

---

## API Documentation (required for any new/changed backend endpoint)

Not applicable — internal auth middleware change only.

---

## Documentation Updates

* [x] Not applicable

---

## Checklist

* [x] I have read `CONTRIBUTING.md`
* [ ] I rebased/merged the latest `main` into this branch
* [x] I tested my changes locally (see Testing Performed above)
* [x] This PR is scoped to one logical change
* [x] I did not commit any secrets, credentials, or real `.env` files
