### PR TITLE
fix: updateOpportunity silently fails for non-ObjectId IDs

### DIFF
--- a/src/api/controllers/opportunityController.ts
+++ b/src/api/controllers/opportunityController.ts
@@ -485,7 +485,9 @@ export const updateOpportunity = async (req: Request, res: Response) => {
     const id = Array.isArray(rawId) ? rawId[0] : rawId;
 
     const oid = safeObjectId(id);
-    const queryId = oid || id;
+    const query = oid
+      ? { _id: oid }
+      : { $or: [{ dedupe_hash: id }, { id: id }] };
 
     const updateData = { ...req.body, updated_at: new Date() };
     delete updateData._id;
@@ -498,7 +500,7 @@ export const updateOpportunity = async (req: Request, res: Response) => {
     if (updateData.tags) updateData.tags = sanitizeArray(updateData.tags);
 
     const result = await dbCommand.collection("opportunities").updateOne(
-      { _id: queryId },
+      query,
       { $set: updateData }
     );
 


### PR DESCRIPTION
## Description

This PR fixes a silent failure in `updateOpportunity` where updating an opportunity by a non-ObjectId ID (e.g., `fb_abc123` from curated fallbacks, or Meilisearch-derived IDs) would always return `{ updated: false }` with no error.

The root cause: `safeObjectId()` returns `null` for non-24-character-hex strings, and the fallback `queryId = id` was a raw string used in `{ _id: queryId }`. MongoDB stores `_id` as `ObjectId` type, so `{ _id: "some_string" }` matches no documents. The `updateOne` returns `{ modifiedCount: 0 }` silently.

This PR changes the query logic to fall back to alternative fields (`dedupe_hash`, `id`) via `$or` when the ID cannot be parsed as a valid ObjectId.

---

## Related Issue

* Closes #496

---

## Component(s) Affected

* [x] Backend (`server/`)
* [ ] Mobile app (`rhythma_flutter/`)
* [ ] Web app (`web/`)
* [ ] Landing page (`landing-page/`)
* [ ] Docs only (README, CONTRIBUTING, architecture, etc.)
* [ ] CI / tooling

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor (no behavior change)
* [ ] Tests
* [ ] Other:

---

## Testing Performed

### Commands executed

* [ ] `npm test`
* [x] `npm run lint`
* [x] `npm run build`
* [x] Manual verification

### Manually verified

* Changed query from `{ _id: queryId }` to conditional query: ObjectId path vs `$or` fallback.
* Verified ObjectId hex strings still use the direct `{ _id: oid }` path.
* Verified non-ObjectId strings fall back to `{ $or: [{ dedupe_hash: id }, { id: id }] }`.
* Verified TypeScript compilation passes with no new errors.

### Edge cases considered

* 24-char hex ObjectId — direct lookup, no change.
* Short IDs like `fb_abc` — falls back to `$or` with dedupe_hash and id fields.
* IDs with special characters — MongoDB `$or` handles these correctly.
* Empty/missing id — Express route param validation handles this.

---

## API Documentation (required for any new/changed backend endpoint)

Not applicable — internal query logic change only.

---

## Documentation Updates

* [x] Not applicable

---

## Checklist

* [x] I have read `CONTRIBUTING.md`
* [ ] I rebased/merged the latest `main` into this branch
* [x] I tested my changes locally (see Testing Performed above)
* [x] This PR is scoped to one logical change
* [x] I did not commit any secrets, credentials, or real `.env` files
