### PR TITLE
Implement stale-while-revalidate strategy for community comments

### DIFF
--- a/src/components/Tabs/Community.tsx
+++ b/src/components/Tabs/Community.tsx
@@ -181,6 +181,7 @@ export default function Community() {
 
     if (!commentsMap[postId]) {
       setLoadingCommentsPostId(postId);
+    }
       try {
         const res = await fetch(`/api/v1/posts/${postId}/comments`);
         if (res.ok) {
@@ -192,7 +193,6 @@ export default function Community() {
       } finally {
         setLoadingCommentsPostId(null);
       }
-    }
   };
 
   const handleAddComment = async (postId: string) => {


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary

This PR implements a stale-while-revalidate strategy for community comments to improve responsiveness while keeping comment data up to date.

---

## ✨ Changes

- Display cached comments immediately when reopening a discussion.
- Fetch the latest comments in the background every time comments are opened.
- Refresh the cached comments after a successful fetch.
- Show loading indicators only when comments are not already cached.

---

## ✅ Benefits

- Faster user experience with instant display of cached comments.
- Automatically keeps comments synchronized with the latest data.
- Reduces unnecessary loading states while preserving existing functionality.

---

## 🔗 Related Issue

Fixes #543