### PR TITLE
Fix #547: Add markdown support in Apply Assist

### DIFF
--- a/src/components/ui/ApplyAssistModal.tsx
+++ b/src/components/ui/ApplyAssistModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { X, Copy, Check, Loader2, FileText, Sparkles } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
+import ReactMarkdown from 'react-markdown';
 
 interface ApplyAssistModalProps {
   isOpen: boolean;
@@ -84,8 +85,10 @@ export default function ApplyAssistModal({ isOpen, onClose, content, isLoading, 
                       )}
                     </button>
                   </div>
-                  <div className="bg-gray-50 p-6 rounded-xl border border-gray-100 text-sm text-gray-800 whitespace-pre-wrap leading-relaxed font-serif">
-                    {content}
+                  <div className="bg-gray-50 p-6 rounded-xl border border-gray-100 text-sm text-gray-800 leading-relaxed font-serif">
+                    <div className="prose prose-sm prose-blue max-w-none">
+                      <ReactMarkdown>{content}</ReactMarkdown>
+                    </div>
                   </div>
                   <div className="mt-6 flex items-start gap-3 p-4 bg-amber-50 rounded-lg border border-amber-100 italic text-xs text-amber-800">
                     <span className="font-bold shrink-0">Note:</span>


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Summary

Goal: Parse and safely render Markdown content within the Apply Assist modal, utilizing existing Tailwind typography classes. Changes made in ApplyAssistModal.tsx:

Added Dependency Usage: Imported react-markdown to handle the parsing and safe rendering of markdown strings (which inherently prevents unsafe HTML injection).
Wrapped Content: Replaced the plain {content} block with <ReactMarkdown>{content}</ReactMarkdown>.
Applied Tailwind Typography: Because react-markdown v9+ no longer accepts a className prop directly, I wrapped the <ReactMarkdown> element inside a <div> and applied the classes prose prose-sm prose-blue max-w-none to it. This automatically styles elements like **bold**, # headings, 1. numbered lists, and - bullet points nicely using your project's existing theme.

Closes Issue(#547)  

---

## 🧪 Testing

- [x] Tested locally
- [x] Added/updated tests (if applicable)
- [x] Screenshots attached (if applicable)

---

## 📸 Screenshots

<!-- Add screenshots or screen recordings here if applicable -->

---

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [x] I have updated the documentation (if required).
- [x] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

❤️ Thank you for contributing!