### PR TITLE
Fix #546: Add screen reader accessibility features to modals

### DIFF
--- a/src/components/ui/ApplyAssistModal.tsx
+++ b/src/components/ui/ApplyAssistModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { X, Copy, Check, Loader2, FileText, Sparkles } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 
@@ -12,6 +12,57 @@ interface ApplyAssistModalProps {
 
 export default function ApplyAssistModal({ isOpen, onClose, content, isLoading, opportunityTitle }: ApplyAssistModalProps) {
   const [copied, setCopied] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previousFocus = document.activeElement as HTMLElement;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+
+      if (e.key === 'Tab' && modalRef.current) {
+        const focusableElements = modalRef.current.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        ) as NodeListOf<HTMLElement>;
+
+        if (focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === firstElement) {
+            lastElement.focus();
+            e.preventDefault();
+          }
+        } else {
+          if (document.activeElement === lastElement) {
+            firstElement.focus();
+            e.preventDefault();
+          }
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    if (modalRef.current) {
+      const focusable = modalRef.current.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])') as NodeListOf<HTMLElement>;
+      if (focusable.length > 0) {
+        focusable[0].focus();
+      }
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previousFocus?.focus();
+    };
+  }, [isOpen, onClose]);
 
   const handleCopy = () => {
     if (content) {
@@ -33,6 +84,10 @@ export default function ApplyAssistModal({ isOpen, onClose, content, isLoading, 
             className="absolute inset-0 bg-gray-900/40 backdrop-blur-sm"
           />
           <motion.div
+            ref={modalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="apply-assist-title"
             initial={{ scale: 0.95, opacity: 0, y: 20 }}
             animate={{ scale: 1, opacity: 1, y: 0 }}
             exit={{ scale: 0.95, opacity: 0, y: 20 }}
@@ -45,7 +100,7 @@ export default function ApplyAssistModal({ isOpen, onClose, content, isLoading, 
                   <Sparkles className="w-5 h-5" />
                 </div>
                 <div>
-                  <h3 className="font-bold text-gray-900 leading-none mb-1 text-lg">Apply Assist</h3>
+                  <h3 id="apply-assist-title" className="font-bold text-gray-900 leading-none mb-1 text-lg">Apply Assist</h3>
                   <p className="text-xs font-medium text-gray-500">AI-generated draft for {opportunityTitle}</p>
                 </div>
               </div>

--- a/src/components/ui/ShareModal.tsx
+++ b/src/components/ui/ShareModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { X, Twitter, Linkedin, MessageCircle, Copy, Check } from 'lucide-react';
 
 interface ShareModalProps {
@@ -9,6 +9,57 @@ interface ShareModalProps {
 
 export default function ShareModal({ isOpen, onClose, opportunity }: ShareModalProps) {
   const [copied, setCopied] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previousFocus = document.activeElement as HTMLElement;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+
+      if (e.key === 'Tab' && modalRef.current) {
+        const focusableElements = modalRef.current.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        ) as NodeListOf<HTMLElement>;
+
+        if (focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === firstElement) {
+            lastElement.focus();
+            e.preventDefault();
+          }
+        } else {
+          if (document.activeElement === lastElement) {
+            firstElement.focus();
+            e.preventDefault();
+          }
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    if (modalRef.current) {
+      const focusable = modalRef.current.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])') as NodeListOf<HTMLElement>;
+      if (focusable.length > 0) {
+        focusable[0].focus();
+      }
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previousFocus?.focus();
+    };
+  }, [isOpen, onClose]);
 
   if (!isOpen || !opportunity) return null;
 
@@ -29,9 +80,15 @@ export default function ShareModal({ isOpen, onClose, opportunity }: ShareModalP
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-gray-900/50 backdrop-blur-sm">
-      <div className="bg-white rounded-xl shadow-xl w-full max-w-sm overflow-hidden animate-in fade-in zoom-in-95 duration-200">
+      <div 
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="share-modal-title"
+        className="bg-white rounded-xl shadow-xl w-full max-w-sm overflow-hidden animate-in fade-in zoom-in-95 duration-200"
+      >
         <div className="p-4 border-b border-gray-100 flex justify-between items-center bg-gray-50/50">
-          <h3 className="font-semibold text-gray-900">Share Opportunity</h3>
+          <h3 id="share-modal-title" className="font-semibold text-gray-900">Share Opportunity</h3>
           <button onClick={onClose} className="p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors">
             <X className="w-5 h-5" />
           </button>


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Summary
Make the modals compliant with web accessibility (a11y) standards for assistive tech and keyboard-only users. Changes made in both ShareModal.tsx and ApplyAssistModal.tsx:

ARIA Attributes: Added role="dialog", aria-modal="true", and aria-labelledby to the primary modal container. We also gave the title header (<h3>) an id matching the aria-labelledby value so screen readers can properly announce the modal's purpose.
Escape Key Support: Added a global keydown event listener attached to the document inside a useEffect hook. If the user presses the Escape key, it triggers the onClose() function.
Keyboard Focus Trapping:
Queried all focusable elements inside the modal (buttons, inputs, links, textareas, etc.).
Added a keydown handler for the Tab key. If the user tabs past the last focusable element, focus wraps back to the first one. If they Shift + Tab past the first element, focus loops to the last one.
Restoring Focus on Close: Inside the useEffect, we capture the currently focused element before the modal opens (const previousFocus = document.activeElement). In the cleanup function of the hook, we call previousFocus.focus(), gracefully returning the user's cursor to whichever button triggered the modal.
---
Closes Issue #546 
---

## 🧪 Testing

- [ ] Tested locally
- [ ] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)

---

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [x] I have updated the documentation (if required).
- [x] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

❤️ Thank you for contributing!