### PR TITLE
feat: implement LRU cache for AI responses

### DIFF
--- a/src/api/genai.ts
+++ b/src/api/genai.ts
@@ -20,20 +20,35 @@ export function getGenAI(): GoogleGenAI | null {
   return _genAI;
 }
 
-// In-memory cache for AI generation prompts and resume reviews
-const aiCache = new Map<string, { data: any; timestamp: number }>();
-const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+import { LRUCache } from "../utils/lruCache.js";
+
+// Configurable LRU cache for AI generation prompts and resume reviews (Issue #593)
+const MAX_CACHE_SIZE = process.env.AI_CACHE_MAX_SIZE
+  ? parseInt(process.env.AI_CACHE_MAX_SIZE, 10)
+  : 100;
+const CACHE_TTL_MS = process.env.AI_CACHE_TTL_MS
+  ? parseInt(process.env.AI_CACHE_TTL_MS, 10)
+  : 60 * 60 * 1000; // 1 hour
+
+export const aiCache = new LRUCache<string, any>({
+  maxSize: MAX_CACHE_SIZE,
+  defaultTtlMs: CACHE_TTL_MS,
+});
 
 export function getCachedResponse(key: string): any | null {
-  const entry = aiCache.get(key);
-  if (entry && (Date.now() - entry.timestamp < CACHE_TTL_MS)) {
-    return entry.data;
-  }
-  return null;
+  return aiCache.get(key);
 }
 
-export function setCachedResponse(key: string, data: any) {
-  aiCache.set(key, { data, timestamp: Date.now() });
+export function setCachedResponse(key: string, data: any, ttlMs?: number) {
+  aiCache.set(key, data, ttlMs);
+}
+
+export function getAICacheStats() {
+  return aiCache.getStats();
+}
+
+export function clearAICache() {
+  aiCache.clear();
 }
 
 export function getAIFallback(prompt: string, expectJson: boolean): string {

--- a/src/utils/lruCache.ts
+++ b/src/utils/lruCache.ts
@@ -1,0 +1,138 @@
+/**
+ * Configurable Least Recently Used (LRU) Cache with Time-To-Live (TTL) Support
+ * Solves Issue #593: Prevents unbounded memory growth for AI responses.
+ */
+
+export interface LRUCacheOptions {
+  maxSize?: number;
+  defaultTtlMs?: number;
+}
+
+export interface CacheEntry<V> {
+  value: V;
+  expiresAt: number;
+}
+
+export interface CacheStats {
+  size: number;
+  maxSize: number;
+  hits: number;
+  misses: number;
+  evictions: number;
+}
+
+export class LRUCache<K = string, V = any> {
+  private cache: Map<K, CacheEntry<V>>;
+  private maxSize: number;
+  private defaultTtlMs: number;
+  private hits: number = 0;
+  private misses: number = 0;
+  private evictions: number = 0;
+
+  constructor(options: LRUCacheOptions = {}) {
+    this.maxSize = options.maxSize && options.maxSize > 0 ? options.maxSize : 100;
+    this.defaultTtlMs = options.defaultTtlMs && options.defaultTtlMs > 0 ? options.defaultTtlMs : 3600000; // 1 hour default
+    this.cache = new Map();
+  }
+
+  public get(key: K): V | null {
+    const entry = this.cache.get(key);
+    if (!entry) {
+      this.misses++;
+      return null;
+    }
+
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(key);
+      this.misses++;
+      return null;
+    }
+
+    // Refresh LRU order (re-inserting moves key to the end of Map order)
+    this.cache.delete(key);
+    this.cache.set(key, entry);
+
+    this.hits++;
+    return entry.value;
+  }
+
+  public set(key: K, value: V, ttlMs?: number): void {
+    const ttl = ttlMs !== undefined && ttlMs > 0 ? ttlMs : this.defaultTtlMs;
+    const expiresAt = Date.now() + ttl;
+
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    } else if (this.cache.size >= this.maxSize) {
+      // Evict least recently used (the first key in Map iteration)
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.cache.delete(oldestKey);
+        this.evictions++;
+      }
+    }
+
+    this.cache.set(key, { value, expiresAt });
+  }
+
+  public has(key: K): boolean {
+    return this.get(key) !== null;
+  }
+
+  public delete(key: K): boolean {
+    return this.cache.delete(key);
+  }
+
+  public clear(): void {
+    this.cache.clear();
+    this.hits = 0;
+    this.misses = 0;
+    this.evictions = 0;
+  }
+
+  public get size(): number {
+    this.evictExpired();
+    return this.cache.size;
+  }
+
+  public getStats(): CacheStats {
+    this.evictExpired();
+    return {
+      size: this.cache.size,
+      maxSize: this.maxSize,
+      hits: this.hits,
+      misses: this.misses,
+      evictions: this.evictions,
+    };
+  }
+
+  public evictExpired(): number {
+    let evictedCount = 0;
+    const now = Date.now();
+    for (const [key, entry] of this.cache.entries()) {
+      if (now > entry.expiresAt) {
+        this.cache.delete(key);
+        evictedCount++;
+      }
+    }
+    return evictedCount;
+  }
+
+  public setMaxSize(newMax: number): void {
+    if (newMax > 0) {
+      this.maxSize = newMax;
+      while (this.cache.size > this.maxSize) {
+        const oldestKey = this.cache.keys().next().value;
+        if (oldestKey !== undefined) {
+          this.cache.delete(oldestKey);
+          this.evictions++;
+        }
+      }
+    }
+  }
+
+  public setDefaultTtl(newTtlMs: number): void {
+    if (newTtlMs > 0) {
+      this.defaultTtlMs = newTtlMs;
+    }
+  }
+}

--- a/tests/lruCache.test.ts
+++ b/tests/lruCache.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { LRUCache } from "../src/utils/lruCache";
+import { getCachedResponse, setCachedResponse, clearAICache } from "../src/api/genai";
+
+describe("LRU Cache for AI Responses (Issue #593)", () => {
+  beforeEach(() => {
+    clearAICache();
+  });
+
+  it("should store and retrieve cached AI responses", () => {
+    const key = "prompt:summarize_resume";
+    const data = "Summary of candidate experience";
+
+    setCachedResponse(key, data);
+    expect(getCachedResponse(key)).toBe(data);
+  });
+
+  it("should evict least recently used entries when cache capacity is exceeded", () => {
+    const cache = new LRUCache<string, string>({ maxSize: 3, defaultTtlMs: 60000 });
+
+    cache.set("key1", "val1");
+    cache.set("key2", "val2");
+    cache.set("key3", "val3");
+
+    // Access key1 to make key2 the least recently used
+    expect(cache.get("key1")).toBe("val1");
+
+    // Add key4, which should evict key2 (the LRU entry)
+    cache.set("key4", "val4");
+
+    expect(cache.get("key1")).toBe("val1");
+    expect(cache.get("key2")).toBe(null); // Evicted!
+    expect(cache.get("key3")).toBe("val3");
+    expect(cache.get("key4")).toBe("val4");
+
+    const stats = cache.getStats();
+    expect(stats.evictions).toBe(1);
+    expect(stats.size).toBe(3);
+  });
+
+  it("should expire items after TTL", async () => {
+    const cache = new LRUCache<string, string>({ maxSize: 10, defaultTtlMs: 50 }); // 50ms TTL
+
+    cache.set("short_lived", "data", 50);
+    expect(cache.get("short_lived")).toBe("data");
+
+    // Wait for TTL to expire
+    await new Promise((resolve) => setTimeout(resolve, 70));
+
+    expect(cache.get("short_lived")).toBe(null);
+  });
+
+  it("should support dynamic max size re-configuration", () => {
+    const cache = new LRUCache<string, string>({ maxSize: 5, defaultTtlMs: 60000 });
+
+    for (let i = 1; i <= 5; i++) {
+      cache.set(`k${i}`, `v${i}`);
+    }
+    expect(cache.size).toBe(5);
+
+    // Reduce capacity to 2 -> should evict 3 entries
+    cache.setMaxSize(2);
+    expect(cache.size).toBe(2);
+    expect(cache.getStats().evictions).toBe(3);
+  });
+
+  it("should track cache stats (hits, misses, evictions)", () => {
+    const cache = new LRUCache<string, string>({ maxSize: 2 });
+
+    cache.get("missing"); // Miss 1
+    cache.set("a", "alpha");
+    cache.get("a"); // Hit 1
+    cache.set("b", "beta");
+    cache.set("c", "gamma"); // Evicts "a"
+
+    const stats = cache.getStats();
+    expect(stats.hits).toBe(1);
+    expect(stats.misses).toBe(1);
+    expect(stats.evictions).toBe(1);
+    expect(stats.size).toBe(2);
+  });
+});


### PR DESCRIPTION

Closes #593

## 🎯 Overview
Replaces the unbounded in-memory `Map` implementation in the AI generation module with a bounded, configurable Least Recently Used (LRU) Cache supporting Time-To-Live (TTL) expiration to prevent memory leaks and improve application stability.

## 🛠️ Changes Made
- **Implemented LRU Cache Utility (`src/utils/lruCache.ts`)**:
  - Created a generic `LRUCache<K, V>` class supporting configurable `maxSize` and `defaultTtlMs`.
  - Re-orders keys on read (`get`) and write (`set`) to accurately track least recently used entries.
  - Evicts oldest (LRU) entries when capacity limit is reached.
  - Automatically handles TTL expiration and exposes cache statistics (`hits`, `misses`, `evictions`, `size`).

- **Refactored AI Module (`src/api/genai.ts`)**:
  - Replaced `Map` instance with `LRUCache` instance.
  - Added configuration via environment variables: `AI_CACHE_MAX_SIZE` (default `100`) and `AI_CACHE_TTL_MS` (default `3600000` / 1 hour).
  - Exported helper functions `getAICacheStats()` and `clearAICache()`.

- **Unit Testing (`tests/lruCache.test.ts`)**:
  - Added test suite covering cache insertion/retrieval, LRU eviction order when capacity is exceeded, TTL expiration, dynamic resizing (`setMaxSize`), and statistics tracking.

## 🧪 Verification & Test Results
- Ran `npx vitest run tests/lruCache.test.ts`:
  - `✓ tests/lruCache.test.ts (5 tests) 93ms`
- Verified that cache size remains bounded under high volume and LRU entries are evicted cleanly.
