### PR TITLE
feat(ui): add empty and error states across list views

### DIFF
--- a/src/components/Tabs/BountyBoard.tsx
+++ b/src/components/Tabs/BountyBoard.tsx
@@ -4,11 +4,13 @@ import { auth } from '../../lib/firebase';
 import { Bounty } from '../../types';
 import Leaderboard from '../ui/Leaderboard';
 import BountyChat from '../BountyChat';
+import { EmptyState, ErrorState } from '../ui/states';
 
 export default function BountyBoard() {
   const { profile, karmaBalance } = useAppContext();
   const [bounties, setBounties] = useState<Bounty[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   
   const [showPostModal, setShowPostModal] = useState(false);
   const [newTitle, setNewTitle] = useState("");
@@ -18,12 +20,15 @@ export default function BountyBoard() {
   const [activeChatBounty, setActiveChatBounty] = useState<Bounty | null>(null);
 
   const fetchBounties = async () => {
+    setError(null);
     try {
       const res = await fetch('/api/v1/bounties');
       const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to load bounties');
       if (data.items) setBounties(data.items);
     } catch (e) {
       console.error(e);
+      setError(e instanceof Error ? e.message : 'Failed to load bounties');
     } finally {
       setLoading(false);
     }
@@ -112,12 +117,20 @@ export default function BountyBoard() {
             <div className="animate-pulse space-y-4">
               {[1,2,3].map(i => <div key={i} className="h-32 bg-gray-100 dark:bg-gray-800 rounded-xl w-full" />)}
             </div>
+          ) : error ? (
+            <ErrorState
+              description={error}
+              onRetry={() => {
+                setLoading(true);
+                void fetchBounties();
+              }}
+              retrying={loading}
+            />
           ) : bounties.length === 0 ? (
-            <div className="bg-white dark:bg-gray-800 rounded-xl p-10 text-center border border-gray-100 dark:border-gray-700">
-              <div className="text-4xl mb-4">🎯</div>
-              <h3 className="text-lg font-bold text-gray-900 dark:text-white mb-2">No active bounties</h3>
-              <p className="text-gray-500">Be the first to ask for help from the community!</p>
-            </div>
+            <EmptyState
+              title="No active bounties"
+              description="Be the first to ask for help from the community!"
+            />
           ) : bounties.map(bounty => (
             <div key={bounty.id} className="bg-white dark:bg-gray-800 rounded-xl p-5 border border-gray-100 dark:border-gray-700 shadow-sm hover:shadow-md transition">
               <div className="flex justify-between items-start mb-3">

--- a/src/components/Tabs/CampusAlumniHub.tsx
+++ b/src/components/Tabs/CampusAlumniHub.tsx
@@ -29,6 +29,7 @@ import {
   TrendingUp
 } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
+import { EmptyState } from '../ui/states';
 
 /**
  * CampusAlumniHub Component
@@ -367,8 +368,15 @@ export default function CampusAlumniHub() {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {filteredChapters.map((c) => (
+          {filteredChapters.length === 0 ? (
+            <EmptyState
+              title="No chapters found"
+              description="No campus chapters match your current search. Try a different college or location."
+              icon={<GraduationCap className="h-6 w-6" aria-hidden="true" />}
+            />
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {filteredChapters.map((c) => (
               <div key={c.id} className="p-5 bg-gray-50 dark:bg-gray-900/60 rounded-2xl border border-gray-200 dark:border-gray-700 space-y-3 flex flex-col justify-between text-xs">
                 <div>
                   <div className="flex items-center justify-between">
@@ -404,7 +412,8 @@ export default function CampusAlumniHub() {
                 </div>
               </div>
             ))}
-          </div>
+            </div>
+          )}
         </div>
       )}
 
@@ -429,8 +438,15 @@ export default function CampusAlumniHub() {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {filteredAlumni.map((a) => (
+          {filteredAlumni.length === 0 ? (
+            <EmptyState
+              title="No alumni found"
+              description="No alumni match your current search. Try a different company or alma mater."
+              icon={<Users className="h-6 w-6" aria-hidden="true" />}
+            />
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {filteredAlumni.map((a) => (
               <div key={a.id} className="p-5 bg-gray-50 dark:bg-gray-900/60 rounded-2xl border border-gray-200 dark:border-gray-700 space-y-3 text-xs">
                 <div className="flex items-center gap-3">
                   <div className="w-10 h-10 rounded-xl bg-indigo-600 text-white font-black text-sm flex items-center justify-center">
@@ -459,7 +475,8 @@ export default function CampusAlumniHub() {
                 </button>
               </div>
             ))}
-          </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/Tabs/CareerMatchStudio.tsx
+++ b/src/components/Tabs/CareerMatchStudio.tsx
@@ -31,6 +31,7 @@ import {
   ArrowUpRight
 } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
+import { EmptyState } from '../ui/states';
 
 /**
  * CareerMatchStudio Component
@@ -538,45 +539,53 @@ export default function CareerMatchStudio() {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {filteredTeammates.map((tm) => (
-              <div key={tm.id} className="p-5 bg-gray-50 dark:bg-gray-900/60 rounded-2xl border border-gray-200 dark:border-gray-700 space-y-3">
-                <div className="flex items-start justify-between">
-                  <div className="flex items-center gap-3">
-                    <div className="w-10 h-10 rounded-xl bg-blue-600 text-white font-black text-sm flex items-center justify-center shadow-md">
-                      {tm.name.charAt(0)}
+          {filteredTeammates.length === 0 ? (
+            <EmptyState
+              title="No teammates found"
+              description="No teammates match your current search. Try a different skill or role."
+              icon={<Users className="h-6 w-6" aria-hidden="true" />}
+            />
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {filteredTeammates.map((tm) => (
+                <div key={tm.id} className="p-5 bg-gray-50 dark:bg-gray-900/60 rounded-2xl border border-gray-200 dark:border-gray-700 space-y-3">
+                  <div className="flex items-start justify-between">
+                    <div className="flex items-center gap-3">
+                      <div className="w-10 h-10 rounded-xl bg-blue-600 text-white font-black text-sm flex items-center justify-center shadow-md">
+                        {tm.name.charAt(0)}
+                      </div>
+                      <div>
+                        <h4 className="font-bold text-gray-900 dark:text-white text-sm">{tm.name}</h4>
+                        <p className="text-xs text-blue-600 dark:text-blue-400 font-medium">{tm.role}</p>
+                      </div>
                     </div>
-                    <div>
-                      <h4 className="font-bold text-gray-900 dark:text-white text-sm">{tm.name}</h4>
-                      <p className="text-xs text-blue-600 dark:text-blue-400 font-medium">{tm.role}</p>
-                    </div>
-                  </div>
-                  <span className="px-2 py-0.5 text-[10px] font-bold bg-amber-100 dark:bg-amber-950 text-amber-700 dark:text-amber-300 rounded-md">
-                    {tm.badge}
-                  </span>
-                </div>
-
-                <div className="text-xs text-gray-600 dark:text-gray-300">
-                  <strong className="text-gray-900 dark:text-white">Looking for:</strong> {tm.lookingFor}
-                </div>
-
-                <div className="flex flex-wrap gap-1.5">
-                  {tm.skills.map(s => (
-                    <span key={s} className="px-2 py-0.5 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 text-[11px] font-medium rounded-md">
-                      {s}
+                    <span className="px-2 py-0.5 text-[10px] font-bold bg-amber-100 dark:bg-amber-950 text-amber-700 dark:text-amber-300 rounded-md">
+                      {tm.badge}
                     </span>
-                  ))}
-                </div>
+                  </div>
 
-                <button
-                  onClick={() => setNotification({ type: 'success', message: `Team invite sent to ${tm.name}!` })}
-                  className="w-full py-2 bg-blue-600 hover:bg-blue-700 text-white text-xs font-bold rounded-xl transition"
-                >
-                  Send Team Invite
-                </button>
-              </div>
-            ))}
-          </div>
+                  <div className="text-xs text-gray-600 dark:text-gray-300">
+                    <strong className="text-gray-900 dark:text-white">Looking for:</strong> {tm.lookingFor}
+                  </div>
+
+                  <div className="flex flex-wrap gap-1.5">
+                    {tm.skills.map(s => (
+                      <span key={s} className="px-2 py-0.5 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 text-[11px] font-medium rounded-md">
+                        {s}
+                      </span>
+                    ))}
+                  </div>
+
+                  <button
+                    onClick={() => setNotification({ type: 'success', message: `Team invite sent to ${tm.name}!` })}
+                    className="w-full py-2 bg-blue-600 hover:bg-blue-700 text-white text-xs font-bold rounded-xl transition"
+                  >
+                    Send Team Invite
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/Tabs/DeveloperApiPortal.tsx
+++ b/src/components/Tabs/DeveloperApiPortal.tsx
@@ -28,6 +28,7 @@ import {
   FileJson
 } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
+import { EmptyState } from '../ui/states';
 
 /**
  * DeveloperApiPortal Component
@@ -371,46 +372,62 @@ func main() {
           </div>
 
           <div className="space-y-3">
-            {apiKeys.map((k) => {
-              const isShowing = showKeyId === k.id;
-              return (
-                <div key={k.id} className="p-4 bg-gray-50 dark:bg-gray-900/60 rounded-2xl border border-gray-200 dark:border-gray-700 text-xs space-y-2">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <Key size={16} className="text-sky-600" />
-                      <span className="font-bold text-gray-900 dark:text-white">{k.name}</span>
-                      <span className="px-2 py-0.5 text-[10px] font-bold bg-sky-100 dark:bg-sky-950 text-sky-700 dark:text-sky-300 rounded-md">
-                        {k.environment}
-                      </span>
+            {apiKeys.length === 0 ? (
+              <EmptyState
+                title="No API keys yet"
+                description="Generate your first API key to authenticate requests to the YuvaHub API."
+                icon={<Key className="h-6 w-6" aria-hidden="true" />}
+                action={
+                  <button
+                    onClick={() => setNewKeyModal(true)}
+                    className="px-4 py-2 bg-sky-600 hover:bg-sky-700 text-white text-xs font-bold rounded-xl transition flex items-center gap-1"
+                  >
+                    <Plus size={14} /> Generate New Key
+                  </button>
+                }
+              />
+            ) : (
+              apiKeys.map((k) => {
+                const isShowing = showKeyId === k.id;
+                return (
+                  <div key={k.id} className="p-4 bg-gray-50 dark:bg-gray-900/60 rounded-2xl border border-gray-200 dark:border-gray-700 text-xs space-y-2">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <Key size={16} className="text-sky-600" />
+                        <span className="font-bold text-gray-900 dark:text-white">{k.name}</span>
+                        <span className="px-2 py-0.5 text-[10px] font-bold bg-sky-100 dark:bg-sky-950 text-sky-700 dark:text-sky-300 rounded-md">
+                          {k.environment}
+                        </span>
+                      </div>
+
+                      <button
+                        onClick={() => handleRevokeKey(k.id)}
+                        className="text-red-500 hover:underline font-bold text-[11px]"
+                      >
+                        Revoke
+                      </button>
                     </div>
 
-                    <button
-                      onClick={() => handleRevokeKey(k.id)}
-                      className="text-red-500 hover:underline font-bold text-[11px]"
-                    >
-                      Revoke
-                    </button>
-                  </div>
+                    <div className="flex items-center gap-2 font-mono bg-white dark:bg-gray-800 p-2.5 rounded-xl border border-gray-200 dark:border-gray-700">
+                      <span className="flex-1 truncate text-gray-700 dark:text-gray-300">
+                        {isShowing ? k.token : `${k.token.substring(0, 10)}••••••••••••••••`}
+                      </span>
+                      <button
+                        onClick={() => setShowKeyId(isShowing ? null : k.id)}
+                        className="text-gray-400 hover:text-gray-600"
+                      >
+                        {isShowing ? <EyeOff size={14} /> : <Eye size={14} />}
+                      </button>
+                    </div>
 
-                  <div className="flex items-center gap-2 font-mono bg-white dark:bg-gray-800 p-2.5 rounded-xl border border-gray-200 dark:border-gray-700">
-                    <span className="flex-1 truncate text-gray-700 dark:text-gray-300">
-                      {isShowing ? k.token : `${k.token.substring(0, 10)}••••••••••••••••`}
-                    </span>
-                    <button
-                      onClick={() => setShowKeyId(isShowing ? null : k.id)}
-                      className="text-gray-400 hover:text-gray-600"
-                    >
-                      {isShowing ? <EyeOff size={14} /> : <Eye size={14} />}
-                    </button>
+                    <div className="flex items-center justify-between text-[11px] text-gray-500 dark:text-gray-400 pt-1">
+                      <span>Scope: <code className="text-sky-600">{k.scope}</code></span>
+                      <span>Last Used: {k.lastUsed}</span>
+                    </div>
                   </div>
-
-                  <div className="flex items-center justify-between text-[11px] text-gray-500 dark:text-gray-400 pt-1">
-                    <span>Scope: <code className="text-sky-600">{k.scope}</code></span>
-                    <span>Last Used: {k.lastUsed}</span>
-                  </div>
-                </div>
-              );
-            })}
+                );
+              })
+            )}
           </div>
         </div>
       )}
@@ -519,21 +536,29 @@ func main() {
           </form>
 
           <div className="space-y-3">
-            {webhooks.map((w) => (
-              <div key={w.id} className="p-4 bg-gray-50 dark:bg-gray-900/60 rounded-2xl border border-gray-200 dark:border-gray-700 text-xs space-y-1">
-                <div className="flex items-center justify-between">
-                  <span className="font-bold text-sky-600 dark:text-sky-400">{w.event}</span>
-                  <span className="px-2 py-0.5 text-[10px] font-bold bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300 rounded-md">
-                    {w.status}
-                  </span>
+            {webhooks.length === 0 ? (
+              <EmptyState
+                title="No webhooks registered"
+                description="Register your first webhook endpoint to receive real-time event notifications."
+                icon={<Webhook className="h-6 w-6" aria-hidden="true" />}
+              />
+            ) : (
+              webhooks.map((w) => (
+                <div key={w.id} className="p-4 bg-gray-50 dark:bg-gray-900/60 rounded-2xl border border-gray-200 dark:border-gray-700 text-xs space-y-1">
+                  <div className="flex items-center justify-between">
+                    <span className="font-bold text-sky-600 dark:text-sky-400">{w.event}</span>
+                    <span className="px-2 py-0.5 text-[10px] font-bold bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300 rounded-md">
+                      {w.status}
+                    </span>
+                  </div>
+                  <div className="font-mono text-gray-900 dark:text-white">{w.url}</div>
+                  <div className="text-[11px] text-gray-500 dark:text-gray-400 pt-1 flex items-center justify-between">
+                    <span>Last Delivery: {w.lastDelivered}</span>
+                    <span>Total Events: {w.deliveriesCount}</span>
+                  </div>
                 </div>
-                <div className="font-mono text-gray-900 dark:text-white">{w.url}</div>
-                <div className="text-[11px] text-gray-500 dark:text-gray-400 pt-1 flex items-center justify-between">
-                  <span>Last Delivery: {w.lastDelivered}</span>
-                  <span>Total Events: {w.deliveriesCount}</span>
-                </div>
-              </div>
-            ))}
+              ))
+            )}
           </div>
         </div>
       )}

--- a/src/components/Tabs/GrantFellowshipStudio.tsx
+++ b/src/components/Tabs/GrantFellowshipStudio.tsx
@@ -27,6 +27,7 @@ import {
   PieChart
 } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
+import { EmptyState } from '../ui/states';
 
 /**
  * GrantFellowshipStudio Component
@@ -320,8 +321,15 @@ export default function GrantFellowshipStudio() {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {filteredGrants.map((g) => (
+          {filteredGrants.length === 0 ? (
+            <EmptyState
+              title="No grants found"
+              description="No grants match your current search. Try a different keyword or category."
+              icon={<BookOpen className="h-6 w-6" aria-hidden="true" />}
+            />
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {filteredGrants.map((g) => (
               <div key={g.id} className="p-5 bg-gray-50 dark:bg-gray-900/60 rounded-2xl border border-gray-200 dark:border-gray-700 space-y-3 flex flex-col justify-between text-xs">
                 <div>
                   <div className="flex items-center justify-between">
@@ -353,7 +361,8 @@ export default function GrantFellowshipStudio() {
                 </div>
               </div>
             ))}
-          </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/Tabs/InterviewPrepStudio.tsx
+++ b/src/components/Tabs/InterviewPrepStudio.tsx
@@ -28,6 +28,7 @@ import {
   BarChart3
 } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
+import { EmptyState } from '../ui/states';
 
 /**
  * InterviewPrepStudio Component
@@ -277,8 +278,15 @@ export default function InterviewPrepStudio() {
             </div>
           </div>
 
-          <div className="space-y-3">
-            {filteredQuestions.map((q) => (
+          {filteredQuestions.length === 0 ? (
+            <EmptyState
+              title="No practice questions found"
+              description="No questions match your current search or topic filter. Try a different keyword."
+              icon={<Brain className="h-6 w-6" aria-hidden="true" />}
+            />
+          ) : (
+            <div className="space-y-3">
+              {filteredQuestions.map((q) => (
               <div key={q.id} className="p-4 bg-gray-50 dark:bg-gray-900/60 rounded-2xl border border-gray-200 dark:border-gray-700 space-y-2 text-xs">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
@@ -309,7 +317,8 @@ export default function InterviewPrepStudio() {
                 </div>
               </div>
             ))}
-          </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/Tabs/Mentorship.tsx
+++ b/src/components/Tabs/Mentorship.tsx
@@ -7,7 +7,7 @@ import { db } from '../../lib/firebase';
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
 import { ChatMessage } from '../../types';
 import { chatWithAIMentorBackend } from '../../services/apiClient';
-import { ErrorState } from '../ui/states';
+import { EmptyState, ErrorState, LoadingState } from '../ui/states';
 import { useAppContext } from '../../context/AppContext';
 
 interface Mentor {
@@ -291,16 +291,18 @@ function BookingModal({ mentor, user, onClose, onSuccess }: { mentor: Mentor; us
 function MyBookingsMain({ user }: { user: any }) {
   const [sessions, setSessions] = useState<MentorshipSession[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchSessions = async () => {
+    setError(null);
     try {
       const res = await fetch(`/api/v1/mentorship/sessions?uid=${user?.uid || 'user_default'}`);
-      if (res.ok) {
-        const data = await res.json();
-        setSessions(data);
-      }
+      if (!res.ok) throw new Error('Failed to load your bookings');
+      const data = await res.json();
+      setSessions(data);
     } catch (err) {
       console.error('Error fetching sessions:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load your bookings');
     } finally {
       setLoading(false);
     }
@@ -375,13 +377,23 @@ END:VCALENDAR`;
       </div>
 
       {loading ? (
-        <div className="p-8 text-center text-xs text-gray-500 font-semibold">Loading bookings...</div>
+        <LoadingState compact title="Loading bookings..." description="" />
+      ) : error ? (
+        <ErrorState
+          title="We could not load your bookings"
+          description={error}
+          onRetry={() => {
+            setLoading(true);
+            void fetchSessions();
+          }}
+          retrying={loading}
+        />
       ) : sessions.length === 0 ? (
-        <div className="bg-white p-8 rounded-2xl border border-gray-200 text-center space-y-2">
-          <Calendar className="w-8 h-8 text-gray-300 mx-auto" />
-          <h4 className="font-bold text-gray-900 text-sm">No Booked Sessions Yet</h4>
-          <p className="text-xs text-gray-500">Book a 1-on-1 session with a mentor from the Human Mentors list.</p>
-        </div>
+        <EmptyState
+          title="No Booked Sessions Yet"
+          description="Book a 1-on-1 session with a mentor from the Human Mentors list."
+          icon={<Calendar className="h-6 w-6" aria-hidden="true" />}
+        />
       ) : (
         <div className="space-y-4">
           {sessions.map(s => (

--- a/src/components/Tabs/MentorshipAdvisoryStudio.tsx
+++ b/src/components/Tabs/MentorshipAdvisoryStudio.tsx
@@ -24,6 +24,7 @@ import {
   Building2
 } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
+import { EmptyState } from '../ui/states';
 
 /**
  * MentorshipAdvisoryStudio Component
@@ -257,8 +258,15 @@ export default function MentorshipAdvisoryStudio() {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {filteredMentors.map((m) => (
+          {filteredMentors.length === 0 ? (
+            <EmptyState
+              title="No mentors found"
+              description="No mentors match your current search. Try a different skill or domain."
+              icon={<UserCheck className="h-6 w-6" aria-hidden="true" />}
+            />
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {filteredMentors.map((m) => (
               <div key={m.id} className="p-5 bg-gray-50 dark:bg-gray-900/60 rounded-2xl border border-gray-200 dark:border-gray-700 space-y-3 text-xs flex flex-col justify-between">
                 <div>
                   <div className="flex items-center gap-3">
@@ -294,7 +302,8 @@ export default function MentorshipAdvisoryStudio() {
                 </div>
               </div>
             ))}
-          </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/Tabs/OpenSourceBountyStudio.tsx
+++ b/src/components/Tabs/OpenSourceBountyStudio.tsx
@@ -26,6 +26,7 @@ import {
   UserCheck
 } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
+import { EmptyState } from '../ui/states';
 
 /**
  * OpenSourceBountyStudio Component
@@ -272,8 +273,15 @@ export default function OpenSourceBountyStudio() {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {filteredBounties.map((b) => (
+          {filteredBounties.length === 0 ? (
+            <EmptyState
+              title="No open source bounties found"
+              description="No bounties match your current filters. Try adjusting the search or language filter."
+              icon={<GitPullRequest className="h-6 w-6" aria-hidden="true" />}
+            />
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {filteredBounties.map((b) => (
               <div key={b.id} className="p-5 bg-gray-50 dark:bg-gray-900/60 rounded-2xl border border-gray-200 dark:border-gray-700 space-y-3 flex flex-col justify-between text-xs">
                 <div>
                   <div className="flex items-center justify-between">
@@ -311,7 +319,8 @@ export default function OpenSourceBountyStudio() {
                 </div>
               </div>
             ))}
-          </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/Tabs/ProjectShowcaseVault.tsx
+++ b/src/components/Tabs/ProjectShowcaseVault.tsx
@@ -25,6 +25,7 @@ import {
   Users
 } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
+import { EmptyState } from '../ui/states';
 
 /**
  * ProjectShowcaseVault Component
@@ -282,8 +283,15 @@ export default function ProjectShowcaseVault() {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {filteredProjects.map((p) => (
+          {filteredProjects.length === 0 ? (
+            <EmptyState
+              title="No projects found"
+              description="No projects match your current search. Try a different keyword or filter."
+              icon={<FolderGit2 className="h-6 w-6" aria-hidden="true" />}
+            />
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {filteredProjects.map((p) => (
               <div key={p.id} className="p-5 bg-gray-50 dark:bg-gray-900/60 rounded-2xl border border-gray-200 dark:border-gray-700 space-y-3 text-xs flex flex-col justify-between">
                 <div>
                   <div className="flex items-center justify-between">
@@ -320,7 +328,8 @@ export default function ProjectShowcaseVault() {
                 </div>
               </div>
             ))}
-          </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/Tabs/ResearchGrantPortal.tsx
+++ b/src/components/Tabs/ResearchGrantPortal.tsx
@@ -25,6 +25,7 @@ import {
   Flame
 } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
+import { EmptyState } from '../ui/states';
 
 /**
  * ResearchGrantPortal Component
@@ -234,8 +235,15 @@ export default function ResearchGrantPortal() {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {filteredGrants.map((g) => (
+          {filteredGrants.length === 0 ? (
+            <EmptyState
+              title="No grants found"
+              description="No grants match your current search. Try a different keyword or category."
+              icon={<BookOpen className="h-6 w-6" aria-hidden="true" />}
+            />
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {filteredGrants.map((g) => (
               <div key={g.id} className="p-5 bg-gray-50 dark:bg-gray-900/60 rounded-2xl border border-gray-200 dark:border-gray-700 space-y-3 text-xs flex flex-col justify-between">
                 <div>
                   <div className="flex items-center justify-between">
@@ -262,7 +270,8 @@ export default function ResearchGrantPortal() {
                 </div>
               </div>
             ))}
-          </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/Tabs/TechEcosystemStudio.tsx
+++ b/src/components/Tabs/TechEcosystemStudio.tsx
@@ -27,6 +27,7 @@ import {
   FileCode
 } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
+import { EmptyState } from '../ui/states';
 
 /**
  * TechEcosystemStudio Component
@@ -245,8 +246,15 @@ export default function TechEcosystemStudio() {
             </div>
           </div>
 
-          <div className="space-y-3">
-            {filteredLeaderboard.map((dev) => (
+          {filteredLeaderboard.length === 0 ? (
+            <EmptyState
+              title="No developers found"
+              description="No contributors match your current search. Try a different filter."
+              icon={<Users className="h-6 w-6" aria-hidden="true" />}
+            />
+          ) : (
+            <div className="space-y-3">
+              {filteredLeaderboard.map((dev) => (
               <div key={dev.id} className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 p-4 bg-gray-50 dark:bg-gray-900/60 rounded-2xl border border-gray-200 dark:border-gray-700 text-xs">
                 <div className="flex items-center gap-3">
                   <div className="w-10 h-10 rounded-xl bg-emerald-600 text-white font-black text-sm flex items-center justify-center">
@@ -271,7 +279,8 @@ export default function TechEcosystemStudio() {
                 </div>
               </div>
             ))}
-          </div>
+            </div>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
Adds proper empty, loading, and error states across all list-based views using reusable components.

## Changes Made
- Switched list pages from ad-hoc markup to the reusable EmptyState, ErrorState, and LoadingState components.
- Added consistent error handling with retry support on data-fetching views.
- Audited and updated: BountyBoard, CampusAlumniHub, CareerMatchStudio, DeveloperApiPortal, GrantFellowshipStudio, InterviewPrepStudio, Mentorship, MentorshipAdvisoryStudio, OpenSourceBountyStudio, ProjectShowcaseVault, ResearchGrantPortal, TechEcosystemStudio.

## Testing
- [x] Ran tsc --noEmit - no type errors in modified files.
- [x] Manually verified empty, loading, and error states render correctly across affected views.
- [ ] Added/updated Playwright UI tests for empty/error states (follow-up).

## Related
Fixes #556