### PR TITLE
refactor(api): finish middleware consolidation under src/api/middlewares (#601)

### DIFF
--- a/src/api/routes/adminRoutes.ts
+++ b/src/api/routes/adminRoutes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { adminHealth, adminMetrics, adminScrapers, scraperStats, scraperLogs, triggerScraper, adminIncidents, adminDeleteUser, adminTelemetryStream, triggerNodeScraper, adminDlqStats, adminInspectDlq, adminReplayDlq, adminPurgeDlq } from "../controllers/adminController.js";
-import { authMiddleware, adminOnly } from "../../middleware/auth.js";
+import { authMiddleware, adminOnly } from "../middlewares/auth.js";
 
 const router = Router();
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,4 +1,0 @@
-/**
- * @deprecated Re-exported for backward compatibility. Import from `src/api/middlewares/auth.js` instead.
- */
-export * from "../api/middlewares/auth.js";

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -1,4 +1,0 @@
-/**
- * @deprecated Re-exported for backward compatibility. Import from `src/api/middlewares/errorHandler.js` instead.
- */
-export * from "../api/middlewares/errorHandler.js";

--- a/src/middlewares/validateRequest.ts
+++ b/src/middlewares/validateRequest.ts
@@ -1,4 +1,0 @@
-/**
- * @deprecated Re-exported for backward compatibility. Import from `src/api/middlewares/validateRequest.js` instead.
- */
-export * from "../api/middlewares/validateRequest.js";


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Summary

Completes the middleware directory consolidation (#601). The main consolidation (PR #609) moved middleware into `src/api/middlewares/` but left deprecated re-export shims at the old `src/middleware/` and `src/middlewares/` locations, and one route still imported through the old path. This removes the shims and aligns the last import with the consolidated directory.

---

## 🔗 Related Issue

issue : #601

---

## ✨ Changes Made

- Updated `src/api/routes/adminRoutes.ts` to import `authMiddleware`/`adminOnly` from `src/api/middlewares/auth.js` instead of the deprecated `src/middleware/auth.js` shim
- Deleted deprecated re-export shims:
  - `src/middleware/auth.ts`
  - `src/middlewares/errorHandler.ts`
  - `src/middlewares/validateRequest.ts`

---

## 🧪 Testing

- [x] Tested locally
- [ ] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)

---

## 📸 Screenshots

N/A — structural refactor, no visual changes.

---

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [ ] I have updated the documentation (if required).
- [ ] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

❤️ Thank you for contributing!
