### PR TITLE
feat: add source-wise scraper adapters

### DIFF
--- a/src/scrapers/adapters/AICTEAdapter.ts
+++ b/src/scrapers/adapters/AICTEAdapter.ts
@@ -1,0 +1,45 @@
+import { IScraperAdapter, ScrapedOpportunity } from './types.js';
+
+export class AICTEAdapter implements IScraperAdapter {
+  readonly sourceName = 'AICTE';
+  readonly baseUrl = 'https://internship.aicte-india.org';
+
+  async scrape(): Promise<ScrapedOpportunity[]> {
+    const results: ScrapedOpportunity[] = [];
+    try {
+      const res = await fetch(`${this.baseUrl}/internship-search.php`, {
+        headers: { "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" }
+      });
+      if (res.ok) {
+        const html = await res.text();
+        const cardRegex = /<div class=["']card-body["']>[\s\S]*?<h5>([\s\S]*?)<\/h5>[\s\S]*?<a href=["']([\s\S]*?)["']/gi;
+        let match;
+        while ((match = cardRegex.exec(html)) !== null) {
+          const title = match[1].replace(/<[^>]+>/g, '').trim();
+          const applyLink = match[2].trim();
+          const opp: ScrapedOpportunity = {
+            title: title || 'AICTE Internship Program',
+            organization: 'AICTE Govt of India',
+            applyLink: applyLink.startsWith('http') ? applyLink : `${this.baseUrl}/${applyLink}`,
+            tags: ['AICTE', 'Internship', 'Government', 'India'],
+            deadline: new Date(Date.now() + 45 * 86400000).toISOString(),
+            location: 'India / Remote',
+            opportunityType: 'internship',
+            description: 'AICTE Govt Internship opportunity for engineering and tech students.',
+            sourceName: this.sourceName,
+          };
+          if (this.validate(opp)) {
+            results.push(opp);
+          }
+        }
+      }
+    } catch (err: any) {
+      console.error(`[${this.sourceName}Adapter] Scraping error:`, err.message);
+    }
+    return results;
+  }
+
+  validate(opportunity: Partial<ScrapedOpportunity>): boolean {
+    return Boolean(opportunity.title && opportunity.applyLink && opportunity.sourceName);
+  }
+}

--- a/src/scrapers/adapters/DevpostAdapter.ts
+++ b/src/scrapers/adapters/DevpostAdapter.ts
@@ -1,0 +1,50 @@
+import { IScraperAdapter, ScrapedOpportunity } from './types.js';
+
+export class DevpostAdapter implements IScraperAdapter {
+  readonly sourceName = 'Devpost';
+  readonly baseUrl = 'https://devpost.com';
+
+  async scrape(): Promise<ScrapedOpportunity[]> {
+    const results: ScrapedOpportunity[] = [];
+    try {
+      const res = await fetch(`${this.baseUrl}/rss`, {
+        headers: { "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" }
+      });
+      if (res.ok) {
+        const text = await res.text();
+        const itemMatches = text.match(/<item>[\s\S]*?<\/item>/gi) || [];
+        for (const item of itemMatches) {
+          const titleMatch = item.match(/<title>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/title>/i);
+          const linkMatch = item.match(/<link>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/link>/i);
+          const descMatch = item.match(/<description>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/description>/i);
+
+          const title = titleMatch ? titleMatch[1].replace(/<[^>]+>/g, '').trim() : '';
+          const applyLink = linkMatch ? linkMatch[1].trim() : '';
+          const description = descMatch ? descMatch[1].replace(/<[^>]+>/g, '').trim() : '';
+
+          const opp: ScrapedOpportunity = {
+            title: title || 'Devpost Hackathon',
+            organization: 'Devpost Community',
+            applyLink: applyLink || `${this.baseUrl}/hackathons`,
+            tags: ['Hackathon', 'Devpost', 'Coding'],
+            deadline: new Date(Date.now() + 14 * 86400000).toISOString(),
+            location: 'Global / Online',
+            opportunityType: 'hackathon',
+            description: description.substring(0, 300) || 'Devpost global hackathon challenge.',
+            sourceName: this.sourceName,
+          };
+          if (this.validate(opp)) {
+            results.push(opp);
+          }
+        }
+      }
+    } catch (err: any) {
+      console.error(`[${this.sourceName}Adapter] Scraping error:`, err.message);
+    }
+    return results;
+  }
+
+  validate(opportunity: Partial<ScrapedOpportunity>): boolean {
+    return Boolean(opportunity.title && opportunity.applyLink && opportunity.sourceName);
+  }
+}

--- a/src/scrapers/adapters/KaggleAdapter.ts
+++ b/src/scrapers/adapters/KaggleAdapter.ts
@@ -1,0 +1,43 @@
+import { IScraperAdapter, ScrapedOpportunity } from './types.js';
+
+export class KaggleAdapter implements IScraperAdapter {
+  readonly sourceName = 'Kaggle';
+  readonly baseUrl = 'https://www.kaggle.com';
+
+  async scrape(): Promise<ScrapedOpportunity[]> {
+    const results: ScrapedOpportunity[] = [];
+    try {
+      const res = await fetch(`${this.baseUrl}/api/v1/competitions/list`, {
+        headers: { "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" }
+      });
+      if (res.ok) {
+        const data = await res.json() as any[];
+        if (Array.isArray(data)) {
+          for (const item of data.slice(0, 10)) {
+            const opp: ScrapedOpportunity = {
+              title: item.title || 'Kaggle ML Competition',
+              organization: item.organizationName || 'Kaggle',
+              applyLink: item.url || `${this.baseUrl}/competitions`,
+              tags: ['Kaggle', 'Machine Learning', 'Data Science'],
+              deadline: item.deadline || new Date(Date.now() + 60 * 86400000).toISOString(),
+              location: 'Online / Global',
+              opportunityType: 'competition',
+              description: item.description || 'Kaggle Machine Learning competition challenge.',
+              sourceName: this.sourceName,
+            };
+            if (this.validate(opp)) {
+              results.push(opp);
+            }
+          }
+        }
+      }
+    } catch (err: any) {
+      console.error(`[${this.sourceName}Adapter] Scraping error:`, err.message);
+    }
+    return results;
+  }
+
+  validate(opportunity: Partial<ScrapedOpportunity>): boolean {
+    return Boolean(opportunity.title && opportunity.applyLink && opportunity.sourceName);
+  }
+}

--- a/src/scrapers/adapters/MLHAdapter.ts
+++ b/src/scrapers/adapters/MLHAdapter.ts
@@ -1,0 +1,45 @@
+import { IScraperAdapter, ScrapedOpportunity } from './types.js';
+
+export class MLHAdapter implements IScraperAdapter {
+  readonly sourceName = 'MLH';
+  readonly baseUrl = 'https://mlh.io';
+
+  async scrape(): Promise<ScrapedOpportunity[]> {
+    const results: ScrapedOpportunity[] = [];
+    try {
+      const res = await fetch(`${this.baseUrl}/seasons/2026/events`, {
+        headers: { "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" }
+      });
+      if (res.ok) {
+        const html = await res.text();
+        const eventRegex = /<div class="event[\s\S]*?<h3 class="event-name">([\s\S]*?)<\/h3>[\s\S]*?<a href="([\s\S]*?)"/gi;
+        let match;
+        while ((match = eventRegex.exec(html)) !== null) {
+          const title = match[1].replace(/<[^>]+>/g, '').trim();
+          const applyLink = match[2].trim();
+          const opp: ScrapedOpportunity = {
+            title,
+            organization: 'Major League Hacking (MLH)',
+            applyLink,
+            tags: ['MLH', 'Student', 'Hackathon'],
+            deadline: new Date(Date.now() + 30 * 86400000).toISOString(),
+            location: 'Global / Hybrid',
+            opportunityType: 'hackathon',
+            description: `Official MLH Season Hackathon event: ${title}`,
+            sourceName: this.sourceName,
+          };
+          if (this.validate(opp)) {
+            results.push(opp);
+          }
+        }
+      }
+    } catch (err: any) {
+      console.error(`[${this.sourceName}Adapter] Scraping error:`, err.message);
+    }
+    return results;
+  }
+
+  validate(opportunity: Partial<ScrapedOpportunity>): boolean {
+    return Boolean(opportunity.title && opportunity.applyLink && opportunity.sourceName);
+  }
+}

--- a/src/scrapers/adapters/UnstopAdapter.ts
+++ b/src/scrapers/adapters/UnstopAdapter.ts
@@ -1,0 +1,44 @@
+import { IScraperAdapter, ScrapedOpportunity } from './types.js';
+
+export class UnstopAdapter implements IScraperAdapter {
+  readonly sourceName = 'Unstop';
+  readonly baseUrl = 'https://unstop.com';
+
+  async scrape(): Promise<ScrapedOpportunity[]> {
+    const results: ScrapedOpportunity[] = [];
+    try {
+      const res = await fetch(`${this.baseUrl}/api/public/opportunity/search-result?opportunity=hackathons`, {
+        headers: { "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" }
+      });
+      if (res.ok) {
+        const json = await res.json() as any;
+        const items = json?.data?.data || json?.data || [];
+        if (Array.isArray(items)) {
+          for (const item of items) {
+            const opp: ScrapedOpportunity = {
+              title: item.title || item.name || 'Unstop Competition',
+              organization: item.organisation?.name || item.company_name || 'Unstop Partner',
+              applyLink: item.public_url || `${this.baseUrl}/competitions`,
+              tags: ['Unstop', 'Competition', 'Students'],
+              deadline: item.end_date || new Date(Date.now() + 20 * 86400000).toISOString(),
+              location: item.region || 'India / Online',
+              opportunityType: 'hackathon',
+              description: item.seo_meta_description || item.details || 'Explore Unstop developer challenge.',
+              sourceName: this.sourceName,
+            };
+            if (this.validate(opp)) {
+              results.push(opp);
+            }
+          }
+        }
+      }
+    } catch (err: any) {
+      console.error(`[${this.sourceName}Adapter] Scraping error:`, err.message);
+    }
+    return results;
+  }
+
+  validate(opportunity: Partial<ScrapedOpportunity>): boolean {
+    return Boolean(opportunity.title && opportunity.applyLink && opportunity.sourceName);
+  }
+}

--- a/src/scrapers/adapters/index.ts
+++ b/src/scrapers/adapters/index.ts
@@ -1,0 +1,7 @@
+export * from './types.js';
+export * from './DevpostAdapter.js';
+export * from './UnstopAdapter.js';
+export * from './MLHAdapter.js';
+export * from './KaggleAdapter.js';
+export * from './AICTEAdapter.js';
+export * from './registry.js';

--- a/src/scrapers/adapters/registry.ts
+++ b/src/scrapers/adapters/registry.ts
@@ -1,0 +1,55 @@
+import { IScraperAdapter, ScrapedOpportunity } from './types.js';
+import { DevpostAdapter } from './DevpostAdapter.js';
+import { UnstopAdapter } from './UnstopAdapter.js';
+import { MLHAdapter } from './MLHAdapter.js';
+import { KaggleAdapter } from './KaggleAdapter.js';
+import { AICTEAdapter } from './AICTEAdapter.js';
+
+export class AdapterRegistry {
+  private adapters: Map<string, IScraperAdapter> = new Map();
+
+  constructor() {
+    // Default dynamic registration of supported adapters
+    this.register(new DevpostAdapter());
+    this.register(new UnstopAdapter());
+    this.register(new MLHAdapter());
+    this.register(new KaggleAdapter());
+    this.register(new AICTEAdapter());
+  }
+
+  register(adapter: IScraperAdapter): void {
+    this.adapters.set(adapter.sourceName.toLowerCase(), adapter);
+    console.log(`[AdapterRegistry] Registered scraper adapter: ${adapter.sourceName}`);
+  }
+
+  getAdapter(sourceName: string): IScraperAdapter | undefined {
+    return this.adapters.get(sourceName.toLowerCase());
+  }
+
+  getAllAdapters(): IScraperAdapter[] {
+    return Array.from(this.adapters.values());
+  }
+
+  async runSource(sourceName: string): Promise<ScrapedOpportunity[]> {
+    const adapter = this.getAdapter(sourceName);
+    if (!adapter) {
+      throw new Error(`No scraper adapter registered for source: ${sourceName}`);
+    }
+    return await adapter.scrape();
+  }
+
+  async runAll(): Promise<Record<string, ScrapedOpportunity[]>> {
+    const results: Record<string, ScrapedOpportunity[]> = {};
+    for (const [key, adapter] of this.adapters.entries()) {
+      try {
+        results[adapter.sourceName] = await adapter.scrape();
+      } catch (err: any) {
+        console.error(`[AdapterRegistry] Failed running adapter ${adapter.sourceName}:`, err.message);
+        results[adapter.sourceName] = [];
+      }
+    }
+    return results;
+  }
+}
+
+export const globalAdapterRegistry = new AdapterRegistry();

--- a/src/scrapers/adapters/types.ts
+++ b/src/scrapers/adapters/types.ts
@@ -1,0 +1,18 @@
+export interface ScrapedOpportunity {
+  title: string;
+  organization: string;
+  applyLink: string;
+  tags: string[];
+  deadline: string;
+  location: string;
+  opportunityType: string;
+  description: string;
+  sourceName: string;
+}
+
+export interface IScraperAdapter {
+  readonly sourceName: string;
+  readonly baseUrl: string;
+  scrape(): Promise<ScrapedOpportunity[]>;
+  validate(opportunity: Partial<ScrapedOpportunity>): boolean;
+}

--- a/tests/test-scraper-adapters.test.ts
+++ b/tests/test-scraper-adapters.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { 
+  AdapterRegistry, 
+  globalAdapterRegistry,
+  DevpostAdapter, 
+  UnstopAdapter, 
+  MLHAdapter, 
+  KaggleAdapter, 
+  AICTEAdapter 
+} from '../src/scrapers/adapters/index.js';
+
+describe('Source-wise Scraper Adapters (#584)', () => {
+  it('should register all default source adapters dynamically', () => {
+    const adapters = globalAdapterRegistry.getAllAdapters();
+    expect(adapters.length).toBeGreaterThanOrEqual(5);
+
+    const names = adapters.map(a => a.sourceName);
+    expect(names).toContain('Devpost');
+    expect(names).toContain('Unstop');
+    expect(names).toContain('MLH');
+    expect(names).toContain('Kaggle');
+    expect(names).toContain('AICTE');
+  });
+
+  it('should retrieve individual adapters correctly', () => {
+    const devpost = globalAdapterRegistry.getAdapter('devpost');
+    expect(devpost).toBeInstanceOf(DevpostAdapter);
+
+    const unstop = globalAdapterRegistry.getAdapter('Unstop');
+    expect(unstop).toBeInstanceOf(UnstopAdapter);
+  });
+
+  it('should allow dynamic registration of custom adapters', async () => {
+    const customRegistry = new AdapterRegistry();
+    const mockAdapter = {
+      sourceName: 'CustomPlatform',
+      baseUrl: 'https://custom.org',
+      scrape: async () => [{
+        title: 'Custom Opportunity',
+        organization: 'Custom Org',
+        applyLink: 'https://custom.org/apply',
+        tags: ['Custom'],
+        deadline: '2026-12-31T00:00:00Z',
+        location: 'Online',
+        opportunityType: 'hackathon',
+        description: 'Test description',
+        sourceName: 'CustomPlatform',
+      }],
+      validate: (opp: any) => Boolean(opp.title),
+    };
+
+    customRegistry.register(mockAdapter);
+    const retrieved = customRegistry.getAdapter('customplatform');
+    expect(retrieved?.sourceName).toBe('CustomPlatform');
+
+    const scraped = await customRegistry.runSource('CustomPlatform');
+    expect(scraped.length).toBe(1);
+    expect(scraped[0].title).toBe('Custom Opportunity');
+  });
+});


### PR DESCRIPTION
## Description
This PR decouples monolithic scraping logic by introducing a modular, extensible Scraper Adapter architecture. Each platform now implements a unified `IScraperAdapter` interface and registers dynamically with a central `AdapterRegistry`.

## Closes
Closes #584

## Proposed Changes
- **Adapter Interface**: Created `src/scrapers/adapters/types.ts` defining `IScraperAdapter` and `ScrapedOpportunity` interfaces.
- **Platform Adapters**: Implemented isolated source adapters:
  - `DevpostAdapter.ts`: Handles Devpost RSS/web listings.
  - `UnstopAdapter.ts`: Handles Unstop API/web search parsing.
  - `MLHAdapter.ts`: Handles Major League Hacking event parsing.
  - `KaggleAdapter.ts`: Handles Kaggle competition API data.
  - `AICTEAdapter.ts`: Handles AICTE Internship portal data.
- **Dynamic Registry**: Built `src/scrapers/adapters/registry.ts` allowing dynamic registration, source lookup, and isolated execution.

## Files Modified / Created
- `src/scrapers/adapters/types.ts` [NEW]
- `src/scrapers/adapters/DevpostAdapter.ts` [NEW]
- `src/scrapers/adapters/UnstopAdapter.ts` [NEW]
- `src/scrapers/adapters/MLHAdapter.ts` [NEW]
- `src/scrapers/adapters/KaggleAdapter.ts` [NEW]
- `src/scrapers/adapters/AICTEAdapter.ts` [NEW]
- `src/scrapers/adapters/registry.ts` [NEW]
- `src/scrapers/adapters/index.ts` [NEW]
- `tests/test-scraper-adapters.test.ts` [NEW]

## Verification
- Added unit tests in `tests/test-scraper-adapters.test.ts`.
- Verified dynamic registration, adapter lookup, and custom source execution (`npx vitest run tests/test-scraper-adapters.test.ts` -> 3/3 passed).