### PR TITLE
docs: add local development setup guide to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,15 @@ We appreciate every contribution, whether it's fixing bugs, improving documentat
 ## Table of Contents
 
 - [Getting Started](#getting-started)
+- [Local Development Setup](#local-development-setup)
+  - [Prerequisites](#prerequisites)
+  - [Environment Variables](#environment-variables)
+  - [Firebase Authentication Setup](#firebase-authentication-setup)
+  - [Database Setup](#database-setup)
+  - [Meilisearch & Redis (Docker)](#meilisearch--redis-docker)
+  - [Running the App](#running-the-app)
+  - [Running Tests](#running-tests)
+  - [Common Issues & Troubleshooting](#common-issues--troubleshooting)
 - [Project Setup](#project-setup)
 - [Repository Structure](#repository-structure)
 - [Creating a Feature Branch](#creating-a-feature-branch)
@@ -38,17 +47,219 @@ cd YuvaHub
 git remote add upstream https://github.com/uditt490-pixel/YuvaHub.git
 ```
 
-4. Install project dependencies.
+4. Follow the [Local Development Setup](#local-development-setup) section below to configure your environment and start the app.
+
+---
+
+# Local Development Setup
+
+This section is the single source of truth for getting YuvaHub running on your machine from scratch.
+
+## Prerequisites
+
+Make sure the following are installed before you begin:
+
+| Tool | Minimum Version | Download |
+| :--- | :--- | :--- |
+| **Node.js** | v18 or higher | https://nodejs.org |
+| **npm** | v9 or higher (bundled with Node.js) | — |
+| **Docker Desktop** | Latest stable | https://www.docker.com/products/docker-desktop/ (optional, for Meilisearch & Redis) |
+| **Git** | Any recent version | https://git-scm.com |
+
+Verify your versions before proceeding:
+
+```bash
+node -v   # should print v18.x.x or higher
+npm -v    # should print v9.x.x or higher
+```
+
+## Environment Variables
+
+All configuration is driven by a `.env` file in the project root. A fully annotated template already exists at [`.env.example`](./.env.example).
+
+```bash
+# macOS / Linux
+cp .env.example .env
+
+# Windows PowerShell
+Copy-Item .env.example .env
+```
+
+Open `.env` and fill in the values. The startup validator will reject a misconfigured environment and print the names of any missing keys.
+
+**The three keys required to start the server are:**
+
+```
+MONGODB_URI      # your MongoDB Atlas (or local) connection string
+JWT_SECRET       # any long random string, e.g. output of: openssl rand -hex 32
+GEMINI_API_KEY   # your Google AI Studio key from https://aistudio.google.com
+```
+
+Everything else is optional for local development. The app runs in a mock/fallback mode when optional services (Redis, RabbitMQ, Meilisearch) are absent.
+
+> **Security reminder:** Never commit your `.env` file. It is already listed in `.gitignore`.
+
+For a full description of every variable, see [docs/ENVIRONMENT_VARIABLES.md](./docs/ENVIRONMENT_VARIABLES.md).
+
+## Firebase Authentication Setup
+
+YuvaHub uses Firebase for user authentication (Google Sign-In).
+
+1. Create a free project at the [Firebase Console](https://console.firebase.google.com/).
+2. Register a **Web App** inside that project and copy the config values.
+3. Paste each value into your `.env` file under the `FIREBASE BROWSER SDK` section:
+
+```
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_STORAGE_BUCKET=
+VITE_FIREBASE_MESSAGING_SENDER_ID=
+VITE_FIREBASE_APP_ID=
+```
+
+4. In the Firebase Console go to **Authentication → Sign-in method** and enable **Google**.
+5. Go to **Authentication → Settings → Authorized domains** and add `localhost`.
+
+## Database Setup
+
+YuvaHub uses **MongoDB** as its primary database.
+
+### Option A — MongoDB Atlas (recommended for first-time contributors)
+
+1. Create a free cluster at [cloud.mongodb.com](https://cloud.mongodb.com).
+2. Click **Connect → Drivers** and copy the connection string.
+3. Replace `<password>` and set your database name, then paste the full URI into your `.env`:
+   ```
+   MONGODB_URI=mongodb+srv://<user>:<password>@cluster0.xxxxx.mongodb.net/yuvahub?retryWrites=true&w=majority
+   MONGODB_DB_NAME=yuvahub
+   ```
+4. In **Network Access**, add `0.0.0.0/0` (allow from anywhere) for local development.
+
+### Option B — Local MongoDB
+
+If you have MongoDB Community Server installed locally:
+
+```
+MONGODB_URI=mongodb://127.0.0.1:27017
+MONGODB_DB_NAME=yuvahub
+```
+
+### Database Seeding
+
+The app seeds itself automatically on first run — the scraper pipeline populates the `opportunities` collection and the server creates all required indexes on startup. No manual seed script is needed.
+
+If you want to verify connectivity before starting the full server:
+
+```bash
+npm run test-mongo
+```
+
+## Meilisearch & Redis (Docker)
+
+Meilisearch powers full-text search and Redis backs BullMQ job queues. Both are **optional for basic local development** — the server falls back to MongoDB-only search and skips queue processing when they are unavailable.
+
+To enable them, make sure Docker Desktop is running, then:
+
+```bash
+docker compose up -d
+```
+
+This starts:
+- **Meilisearch** on `http://localhost:7700` (master key: `yuvahub-dev-master-key`)
+- **Redis** on `localhost:6379`
+
+Then update your `.env` to point at these local instances:
+
+```
+MEILI_HOST=http://127.0.0.1:7700
+MEILI_MASTER_KEY=yuvahub-dev-master-key
+
+REDIS_URL=redis://127.0.0.1:6379
+ENABLE_REDIS=true
+```
+
+To stop the containers:
+
+```bash
+docker compose down
+```
+
+To stop and delete all stored data:
+
+```bash
+docker compose down -v
+```
+
+## Running the App
+
+After completing the setup above, install dependencies and start the development server:
 
 ```bash
 npm install
-```
-
-5. Start the development server.
-
-```bash
 npm run dev
 ```
+
+This starts both the Vite frontend (hot-reload) and the Express backend concurrently.
+
+Open your browser at **http://localhost:5173**.
+
+Other useful scripts:
+
+| Command | Description |
+| :--- | :--- |
+| `npm run dev` | Start frontend + backend in watch mode |
+| `npm run dev:server` | Start only the Express backend |
+| `npm run build` | Compile a production bundle |
+| `npm run start` | Serve the compiled production bundle |
+| `npm run scrape` | Run the opportunity scraper manually |
+| `npm run lint` | TypeScript type-check (no emit) |
+
+## Running Tests
+
+```bash
+# Unit & integration tests (Vitest, single run)
+npm test -- --run
+
+# Unit & integration tests with coverage
+npm run test:coverage
+
+# End-to-end tests (Playwright) — requires a running dev server
+npm run test:e2e
+```
+
+> Use `--run` with Vitest to exit after one pass instead of entering watch mode.
+
+## Common Issues & Troubleshooting
+
+**Server exits immediately with "Missing required environment variables"**
+- Run `npm run dev` and read the printed list of missing keys.
+- The three required keys are `MONGODB_URI`, `JWT_SECRET`, and `GEMINI_API_KEY`.
+- Double-check that your `.env` file is in the project root (same folder as `package.json`).
+
+**`npm install` fails or produces peer-dependency errors**
+- Make sure you are on Node.js v18 or higher (`node -v`).
+- Delete `node_modules` and `package-lock.json`, then re-run `npm install`.
+
+**MongoDB connection refused / authentication failed**
+- For Atlas: verify your IP is whitelisted and the password in the URI is correct.
+- For local MongoDB: confirm the `mongod` process is running.
+
+**Google Sign-In fails or redirects loop**
+- Confirm `localhost` is added to **Authorized Domains** in the Firebase Console.
+- Ensure all `VITE_FIREBASE_*` values in `.env` exactly match the Firebase project config.
+
+**Meilisearch search returns no results**
+- Make sure `docker compose up -d` is running.
+- Confirm `MEILI_HOST` and `MEILI_MASTER_KEY` in `.env` match the values in `docker-compose.yml`.
+- On first run the search index is built in the background — wait a few seconds and refresh.
+
+**Port already in use (5000 or 5173)**
+- Kill the process using that port or change `PORT` / `FRONTEND_URL` in `.env`.
+
+**`tsx` not found / command not recognized**
+- Run `npm install` again to restore dev dependencies.
+- On Windows, try running commands in PowerShell rather than CMD.
 
 ---
 
@@ -73,22 +284,33 @@ git merge upstream/main
 
 # Repository Structure
 
-A typical project structure may look like:
-
 ```
 .
-├── public/
+├── docs/                  # Architecture, deployment, and feature docs
+├── public/                # Static assets served directly (robots.txt, favicon, etc.)
 ├── src/
-│   ├── assets/
-│   ├── components/
-│   ├── pages/
-│   ├── hooks/
-│   ├── utils/
-│   ├── styles/
-│   └── App.jsx
+│   ├── api/
+│   │   ├── controllers/   # Express route handlers (one file per feature)
+│   │   ├── middleware/    # Auth, rate-limiting, validation middleware
+│   │   ├── routes/        # Express router definitions
+│   │   └── db.ts          # MongoDB connection helpers
+│   ├── components/        # React UI components
+│   ├── config/            # App-wide config (swagger, env validation, etc.)
+│   ├── consumers/         # RabbitMQ event consumers
+│   ├── events/            # EventBus abstraction
+│   ├── hooks/             # React custom hooks
+│   ├── pages/             # React page components (one per route)
+│   ├── services/          # Background services (search sync, scrapers, DNL)
+│   └── socket/            # Socket.IO event setup
+├── firestore-tests/       # Firebase Firestore rules emulator tests
+├── functions/             # Firebase Cloud Functions
+├── scripts/               # Utility scripts (secret boundary checks, etc.)
+├── .env.example           # Annotated environment variable template
+├── docker-compose.yml     # Local Meilisearch + Redis containers
+├── firestore.rules        # Firestore security rules
 ├── package.json
-├── README.md
-└── vite.config.js
+├── server.ts              # Express server entry point
+└── vite.config.ts         # Vite build configuration
 ```
 
 Please place new files in the appropriate directory to keep the project organized.


### PR DESCRIPTION
## Summary

Closes #632

New contributors had no single source of truth for running YuvaHub locally. This PR expands CONTRIBUTING.md with a complete **Local Development Setup** section so a first-time contributor can go from clone to running app using only the docs.

## Changes Made

- **Prerequisites table** — Node.js v18+, npm, Docker (optional), Git with version-check commands
- **Environment Variables** — how to copy .env.example, the 3 required keys (MONGODB_URI, JWT_SECRET, GEMINI_API_KEY), and a link to the full env vars doc
- **Firebase Authentication Setup** — step-by-step for creating a Firebase project and enabling Google Sign-In on localhost
- **Database Setup** — MongoDB Atlas (recommended) and local MongoDB options; note that seeding is automatic on first run
- **Meilisearch & Redis (Docker)** — exact docker compose commands, the .env values to set, and teardown instructions
- **Running the App** — 
pm install + 
pm run dev, browser URL, and full scripts reference table
- **Running Tests** — Vitest and Playwright commands
- **Common Issues & Troubleshooting** — 6 actionable fixes covering the most common first-run problems
- **Repository Structure** — replaced the generic placeholder with the actual project layout

## Acceptance Criteria Checklist

- [x] .env.example file exists and is referenced in docs
- [x] Step-by-step local setup guide added to the repo
- [x] Guide covers DB seeding and Meilisearch setup specifically
- [x] A first-time contributor can go from clone to running app using only the docs