### PR TITLE
feat(api): API versioning strategy and deprecation policy (#674)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ For details on advanced configuration, deploy strategies, and architectural desi
 * **Frontend Vercel Deployment:** [DEPLOYMENT.md](./docs/DEPLOYMENT.md)
 * **Backend Render Deployment & Cron Scraper:** [RENDER_DEPLOYMENT_GUIDE.md](./docs/RENDER_DEPLOYMENT_GUIDE.md)
 * **Domain Name Settings:** [DOMAIN_SETUP.md](./docs/DOMAIN_SETUP.md)
+* **API Versioning & Deprecation Policy:** [API_VERSIONING.md](./docs/API_VERSIONING.md)
 
 ---
 

--- a/docs/API_VERSIONING.md
+++ b/docs/API_VERSIONING.md
@@ -1,0 +1,107 @@
+# API Versioning & Deprecation Policy
+
+Tracks [issue #674](https://github.com/uditt490-pixel/YuvaHub/issues/674). This
+document is the single source of truth for how YuvaHub versions its HTTP API,
+how long versions are supported, and how consumers are told (and given time)
+when a version is going away.
+
+## Why
+
+All endpoints historically lived at the root `/api` namespace with no versioning
+or lifecycle policy, which made breaking changes (e.g. the response envelope,
+pagination meta) risky for consumers. URI versioning gives every breaking change
+a safe release path: ship a new `/api/vN` alongside the old one, let consumers
+migrate, then retire the old version on a published schedule.
+
+## Versioning strategy
+
+- API namespaces are URI-versioned: `/api/v1`, `/api/v2`, etc.
+- All **new** endpoints MUST be added under the current versioned namespace
+  (`/api/v1` today). Unversioned root endpoints are only allowed as explicit
+  legacy aliases (see below).
+- The API version is advertised on every response via the `X-API-Version`
+  header.
+- Within a version, changes MUST remain backward compatible. Anything that
+  breaks a consumer (response shape, error envelope, pagination meta, removed
+  fields/params) requires a new version.
+
+### Legacy alias (`/api`)
+
+The unversioned `/api` namespace is a **deprecated legacy alias** that forwards
+to `/api/v1`. It exists purely so existing consumers keep working while they
+migrate. It is subject to the deprecation policy below and is scheduled for
+sunset on **2027-06-30**.
+
+## Lifecycle
+
+| State        | Meaning                                                            |
+| :----------- | :----------------------------------------------------------------- |
+| `active`     | Current version. Fully supported. No deprecation headers.          |
+| `deprecated` | Superseded. Still served, but `Deprecation` + `Sunset` are emitted |
+| `sunset`     | No longer served. Requests return `404`.                           |
+
+The registry in `src/api/versioning/registry.ts` is the source of truth for
+these states.
+
+## Support window & sunset cadence
+
+- A version is supported for at least **12 months** after the next major
+  version is released.
+- Deprecation is announced with the `Deprecation` header when a version becomes
+  deprecated, and must be advertised for at least **6 months** before removal.
+- The exact removal date is announced in the `Sunset` header and in this
+  document.
+
+## Headers
+
+Sent on every matching response:
+
+| Header          | Value                                            | When                                     |
+| :-------------- | :----------------------------------------------- | :--------------------------------------- |
+| `X-API-Version` | e.g. `v1`                                        | Every versioned request (and aliases)    |
+| `Deprecation`   | `true`                                           | Version (or alias) is deprecated         |
+| `Sunset`        | HTTP-date (RFC 1123) of removal, e.g. `Wed, 30 Jun 2027 00:00:00 GMT` | Version (or alias) is deprecated |
+| `Link`          | `rel="deprecation"` + `rel="sunset"` policy links | Version (or alias) is deprecated         |
+
+## Current versions
+
+| Namespace   | Status       | Introduced | Deprecated | Sunset               | Notes                        |
+| :---------- | :----------- | :--------- | :--------- | :------------------- | :--------------------------- |
+| `/api/v1`   | `active`     | 2025-01-01 | —          | —                    | Current version              |
+| `/api`      | `deprecated` | —          | 2026-08-01 | 2027-06-30           | Legacy alias, forwards to v1 |
+
+## Adding a new version (e.g. v2)
+
+1. Register it in `src/api/versioning/registry.ts`:
+   `versions.v2 = { version: "v2", status: "active", introducedAt: "...", docsUrl: "..." }`.
+2. Create `v2Router` and mount it in `src/api/routes/index.ts`:
+   `rootRouter.use("/v2", apiVersionHeaders(), v2Router)`.
+3. Keep `/api/v1` mounted for the support window. The versioning middleware
+   serves both concurrently — verify with the transition tests in
+   `tests/api-versioning.test.ts`.
+4. Document `/api/v2` in `src/config/swagger.ts`.
+
+## Deprecating a version
+
+1. Set the version's `status` to `"deprecated"` and record `deprecatedAt` and a
+   `sunsetAt` date that satisfies the ≥ 6 month notice window in
+   `src/api/versioning/registry.ts`. The middleware starts emitting
+   `Deprecation` + `Sunset` headers automatically.
+2. Announce it in the changelog/PR and update this document.
+3. On the sunset date, remove the version's mount and (later) its registry entry.
+
+## Verifying
+
+The automated suite in `tests/api-versioning.test.ts` covers:
+
+- a **sniff test** asserting legacy `/api` responses stay byte-for-byte stable
+  against `/api/v1` for the deprecation window;
+- that deprecated surfaces emit `Sunset` + `Deprecation` + `Link` headers;
+- that `/api/v1` does **not** emit deprecation headers;
+- concurrent `v1` / `v2` operation during a transition.
+
+Run it with:
+
+```bash
+npx vitest run tests/api-versioning.test.ts
+```

--- a/server.ts
+++ b/server.ts
@@ -50,6 +50,7 @@ import { setSocketIO } from "./src/api/socketInstance.js";
 import { setupSocketEvents } from "./src/socket/index.js";
 import { analyticsBuffer } from "./src/api/analytics.js";
 import apiRoutes from "./src/api/routes/index.js";
+import { apiVersionHeaders } from "./src/api/versioning/middleware.js";
 import swaggerSpec from "./src/config/swagger.js";
 import { validateStartupEnv } from "./src/config/envValidation.js";
 
@@ -60,6 +61,12 @@ validateStartupEnv();
 
 const app = express();
 const server = http.createServer(app);
+
+// Version-aware headers for every /api/* request (Issue #674). Registered
+// before all handlers so app-level routes also advertise version/deprecation
+// metadata. Idempotent, so it composes with the versioning middleware that
+// is also mounted inside apiRoutes.
+app.use("/api", apiVersionHeaders());
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -21,6 +21,7 @@ import analyticsRoutes from "./analyticsRoutes.js";
 import recommendationRoutes from "./recommendationRoutes.js";
 import eventRoutes from "./eventRoutes.js";
 import { errorHandler } from "../middlewares/errorHandler.js";
+import { apiVersionHeaders } from "../versioning/middleware.js";
 
 const rootRouter = Router();
 const v1Router = Router();
@@ -60,9 +61,13 @@ v1Router.get("/health", (_req, res) => {
   res.json({ status: "healthy", timestamp: new Date().toISOString(), architecture: "modular" });
 });
 
-// For dual-version support, mount v1Router on both /api/v1 and /api
-rootRouter.use("/v1", v1Router);
-rootRouter.use("/", v1Router);
+// Canonical versioned namespace. All new endpoints land here by default.
+rootRouter.use("/v1", apiVersionHeaders(), v1Router);
+
+// Graceful legacy alias: forwards unversioned /api/* traffic to v1 while
+// consumers migrate. The versioning middleware marks it as deprecated
+// (Deprecation + Sunset headers) so callers are nudged onto /api/v1.
+rootRouter.use("/", apiVersionHeaders(), v1Router);
 
 // Special alias mappings from server.ts to maintain backward compatibility
 rootRouter.use("/opportunities/search", searchRoutes);

--- a/src/api/versioning/index.ts
+++ b/src/api/versioning/index.ts
@@ -1,0 +1,2 @@
+export * from "./middleware.js";
+export * from "./registry.js";

--- a/src/api/versioning/middleware.ts
+++ b/src/api/versioning/middleware.ts
@@ -1,0 +1,78 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import {
+  API_VERSIONING_POLICY_URL,
+  getLegacyAliasInfo,
+  getVersionInfo,
+  toHttpDate,
+} from "./registry.js";
+
+const VERSION_SEGMENT_PATTERN = /^v(\d+)$/;
+
+export interface ParsedApiVersion {
+  version?: string;
+  legacyAlias?: string;
+}
+
+export function parseVersionFromRequest(
+  req: Pick<Request, "baseUrl" | "path">,
+): ParsedApiVersion | null {
+  const pathSegments = req.path.split("/").filter(Boolean);
+  if (pathSegments[0] === "docs") return null;
+
+  const segments = [...req.baseUrl.split("/"), ...pathSegments].filter(Boolean);
+
+  for (const segment of segments) {
+    const match = VERSION_SEGMENT_PATTERN.exec(segment);
+    if (match) return { version: `v${match[1]}` };
+  }
+
+  if (segments.length > 0) return { legacyAlias: "root" };
+
+  return null;
+}
+
+export function apiVersionHeaders(): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (res.locals.apiVersioningApplied) {
+      return next();
+    }
+    res.locals.apiVersioningApplied = true;
+
+    try {
+      const parsed = parseVersionFromRequest(req);
+
+      if (parsed?.version) {
+        res.setHeader("X-API-Version", parsed.version);
+        const info = getVersionInfo(parsed.version);
+        if (info?.status === "deprecated") {
+          applyDeprecationHeaders(res, info.sunsetAt, info.docsUrl);
+        }
+      } else if (parsed?.legacyAlias) {
+        const alias = getLegacyAliasInfo(parsed.legacyAlias);
+        if (alias) {
+          res.setHeader("X-API-Version", alias.targets);
+          applyDeprecationHeaders(res, alias.sunsetAt, alias.docsUrl);
+        }
+      }
+    } catch {
+      // header bookkeeping must never break the request
+    }
+
+    next();
+  };
+}
+
+function applyDeprecationHeaders(
+  res: Response,
+  sunsetAt: string | undefined,
+  docsUrl: string,
+): void {
+  res.setHeader("Deprecation", "true");
+  const sunset = sunsetAt ? toHttpDate(sunsetAt) : "";
+  if (sunset) res.setHeader("Sunset", sunset);
+  res.append("Link", `<${docsUrl}>; rel="deprecation"; type="text/html"`);
+  res.append(
+    "Link",
+    `<${API_VERSIONING_POLICY_URL}>; rel="sunset"; type="text/html"`,
+  );
+}

--- a/src/api/versioning/registry.ts
+++ b/src/api/versioning/registry.ts
@@ -1,0 +1,66 @@
+export type ApiVersionStatus = "active" | "deprecated";
+
+export interface ApiVersionInfo {
+  version: string;
+  status: ApiVersionStatus;
+  introducedAt: string;
+  deprecatedAt?: string;
+  sunsetAt?: string;
+  migrationTarget?: string;
+  docsUrl: string;
+}
+
+export interface LegacyAliasInfo {
+  targets: string;
+  status: ApiVersionStatus;
+  deprecatedAt: string;
+  sunsetAt: string;
+  docsUrl: string;
+}
+
+export const API_VERSIONING_POLICY_URL =
+  "https://github.com/uditt490-pixel/YuvaHub/blob/main/docs/API_VERSIONING.md";
+
+export const API_V1_DOCS_URL = `${API_VERSIONING_POLICY_URL}#api-v1`;
+
+export const versions: Record<string, ApiVersionInfo> = {
+  v1: {
+    version: "v1",
+    status: "active",
+    introducedAt: "2025-01-01",
+    docsUrl: API_V1_DOCS_URL,
+  },
+};
+
+export const legacyAliases: Record<string, LegacyAliasInfo> = {
+  root: {
+    targets: "v1",
+    status: "deprecated",
+    deprecatedAt: "2026-08-01",
+    sunsetAt: "2027-06-30",
+    docsUrl: API_VERSIONING_POLICY_URL,
+  },
+};
+
+export function getVersionInfo(version: string): ApiVersionInfo | undefined {
+  return versions[version];
+}
+
+export function isVersionDeprecated(version: string): boolean {
+  return versions[version]?.status === "deprecated";
+}
+
+export function getLegacyAliasInfo(key: string): LegacyAliasInfo | undefined {
+  return legacyAliases[key];
+}
+
+export function toHttpDate(isoDate: string): string {
+  const date = new Date(isoDate);
+  return Number.isNaN(date.getTime()) ? "" : date.toUTCString();
+}
+
+export function listDeprecatedVersions(): string[] {
+  return Object.values(versions)
+    .filter((version) => version.status === "deprecated")
+    .map((version) => version.version);
+}

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -7,11 +7,15 @@ const options: swaggerJsdoc.Options = {
       title: "YuvaHub API",
       version: "1.0.0",
       description:
-        "YuvaHub is a community-driven opportunity discovery platform. This API provides endpoints for authentication, opportunities, bookmarks, community forums, mentorship, AI assistance, and more.",
+        "YuvaHub is a community-driven opportunity discovery platform. This API provides endpoints for authentication, opportunities, bookmarks, community forums, mentorship, AI assistance, and more.\n\n**Versioning:** All endpoints live under `/api/v1`. The unversioned `/api` namespace is a deprecated legacy alias and emits `Deprecation` + `Sunset` headers. See the [API versioning & deprecation policy](https://github.com/uditt490-pixel/YuvaHub/blob/main/docs/API_VERSIONING.md) for the support window and sunset cadence.",
+    },
+    externalDocs: {
+      description: "API versioning & deprecation policy",
+      url: "https://github.com/uditt490-pixel/YuvaHub/blob/main/docs/API_VERSIONING.md",
     },
     servers: [
-      { url: "/api/v1", description: "API v1" },
-      { url: "/api", description: "API (legacy)" },
+      { url: "/api/v1", description: "API v1 (current)" },
+      { url: "/api", description: "API (legacy, deprecated — migrate to /api/v1)" },
     ],
     components: {
       securitySchemes: {

--- a/tests/api-versioning.test.ts
+++ b/tests/api-versioning.test.ts
@@ -1,0 +1,251 @@
+import express from "express";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import apiRoutes from "../src/api/routes/index";
+import {
+  apiVersionHeaders,
+  parseVersionFromRequest,
+} from "../src/api/versioning/middleware";
+import {
+  API_VERSIONING_POLICY_URL,
+  getLegacyAliasInfo,
+  getVersionInfo,
+  isVersionDeprecated,
+  legacyAliases,
+  listDeprecatedVersions,
+  toHttpDate,
+  versions,
+} from "../src/api/versioning/registry";
+
+const servers: Array<ReturnType<express.Express["listen"]>> = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        }),
+    ),
+  );
+});
+
+async function startTestServer() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api", apiRoutes);
+
+  app.get("*splat", (_req, res) => {
+    res.status(404).json({ error: "SPA fallback reached" });
+  });
+
+  const server = app.listen(0, "127.0.0.1");
+  servers.push(server);
+
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function startTransitionServer() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api", apiVersionHeaders());
+
+  const legacyRouter = express.Router();
+  legacyRouter.get("/ping", (_req, res) => res.json({ pong: "legacy" }));
+
+  const v1Router = express.Router();
+  v1Router.get("/ping", (_req, res) => res.json({ pong: "v1" }));
+
+  const v2Router = express.Router();
+  v2Router.get("/ping", (_req, res) => res.json({ pong: "v2" }));
+
+  app.use("/api/v2", apiVersionHeaders(), v2Router);
+  app.use("/api/v1", apiVersionHeaders(), v1Router);
+  app.use("/api", legacyRouter);
+
+  const server = app.listen(0, "127.0.0.1");
+  servers.push(server);
+
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function stripVolatile(body: Record<string, unknown>): Record<string, unknown> {
+  const copy = { ...body };
+  delete copy.timestamp;
+  return copy;
+}
+
+describe("parseVersionFromRequest", () => {
+  it("detects a version from the request path", () => {
+    expect(
+      parseVersionFromRequest({ baseUrl: "/api", path: "/v1/health" }),
+    ).toEqual({ version: "v1" });
+  });
+
+  it("detects a version from the router mount baseUrl", () => {
+    expect(
+      parseVersionFromRequest({ baseUrl: "/api/v1", path: "/health" }),
+    ).toEqual({ version: "v1" });
+  });
+
+  it("supports future versions (v2)", () => {
+    expect(
+      parseVersionFromRequest({ baseUrl: "/api/v2", path: "/ping" }),
+    ).toEqual({ version: "v2" });
+  });
+
+  it("flags unversioned requests as the legacy alias", () => {
+    expect(
+      parseVersionFromRequest({ baseUrl: "/api", path: "/opportunities" }),
+    ).toEqual({ legacyAlias: "root" });
+  });
+
+  it("ignores documentation paths", () => {
+    expect(
+      parseVersionFromRequest({ baseUrl: "/api", path: "/docs" }),
+    ).toBeNull();
+  });
+});
+
+describe("API version registry", () => {
+  it("registers v1 as the active version", () => {
+    expect(getVersionInfo("v1")?.status).toBe("active");
+    expect(isVersionDeprecated("v1")).toBe(false);
+  });
+
+  it("registers the legacy /api alias as deprecated", () => {
+    const alias = getLegacyAliasInfo("root");
+    expect(alias?.status).toBe("deprecated");
+    expect(alias?.targets).toBe("v1");
+    expect(alias?.sunsetAt).toBe("2027-06-30");
+    expect(legacyAliases.root).toBeDefined();
+  });
+
+  it("lists no deprecated versions while v1 is active", () => {
+    expect(listDeprecatedVersions()).toEqual([]);
+  });
+
+  it("formats sunset dates as RFC 1123 HTTP dates", () => {
+    expect(toHttpDate("2027-06-30")).toBe("Wed, 30 Jun 2027 00:00:00 GMT");
+  });
+});
+
+describe("legacy alias stability sniff (Issue #674)", () => {
+  it.each(["/health", "/opportunities"])(
+    "legacy %s stays stable against /api/v1",
+    async (path) => {
+      const baseUrl = await startTestServer();
+
+      const [legacy, versioned] = await Promise.all([
+        fetch(`${baseUrl}/api${path}`),
+        fetch(`${baseUrl}/api/v1${path}`),
+      ]);
+
+      expect(legacy.status).toBe(versioned.status);
+      expect(stripVolatile(await legacy.json())).toEqual(
+        stripVolatile(await versioned.json()),
+      );
+    },
+  );
+
+  it("marks the legacy alias as deprecated with Sunset + Link headers", async () => {
+    const baseUrl = await startTestServer();
+    const response = await fetch(`${baseUrl}/api/opportunities`);
+    const link = response.headers.get("link") || "";
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-api-version")).toBe("v1");
+    expect(response.headers.get("deprecation")).toBe("true");
+    expect(response.headers.get("sunset")).toBe(
+      toHttpDate(getLegacyAliasInfo("root")?.sunsetAt || ""),
+    );
+    expect(link).toContain(API_VERSIONING_POLICY_URL);
+    expect(link).toContain('rel="deprecation"');
+    expect(link).toContain('rel="sunset"');
+  });
+
+  it("does not deprecate the canonical /api/v1 namespace", async () => {
+    const baseUrl = await startTestServer();
+    const response = await fetch(`${baseUrl}/api/v1/opportunities`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-api-version")).toBe("v1");
+    expect(response.headers.get("deprecation")).toBeNull();
+    expect(response.headers.get("sunset")).toBeNull();
+  });
+});
+
+describe("concurrent v1/v2 operation during transition", () => {
+  it("serves legacy, v1, and v2 simultaneously", async () => {
+    const baseUrl = await startTransitionServer();
+
+    const legacy = await fetch(`${baseUrl}/api/ping`);
+    expect(legacy.status).toBe(200);
+    expect(await legacy.json()).toEqual({ pong: "legacy" });
+    expect(legacy.headers.get("deprecation")).toBe("true");
+    expect(legacy.headers.get("x-api-version")).toBe("v1");
+
+    const v1 = await fetch(`${baseUrl}/api/v1/ping`);
+    expect(v1.status).toBe(200);
+    expect(await v1.json()).toEqual({ pong: "v1" });
+    expect(v1.headers.get("deprecation")).toBeNull();
+    expect(v1.headers.get("x-api-version")).toBe("v1");
+
+    const v2 = await fetch(`${baseUrl}/api/v2/ping`);
+    expect(v2.status).toBe(200);
+    expect(await v2.json()).toEqual({ pong: "v2" });
+    expect(v2.headers.get("deprecation")).toBeNull();
+    expect(v2.headers.get("x-api-version")).toBe("v2");
+  });
+
+  it("emits each deprecation Link header only once", async () => {
+    const baseUrl = await startTransitionServer();
+    const response = await fetch(`${baseUrl}/api/ping`);
+    const link = response.headers.get("link") || "";
+
+    expect(link.split('rel="deprecation"').length - 1).toBe(1);
+    expect(link.split('rel="sunset"').length - 1).toBe(1);
+  });
+});
+
+describe("deprecated version advertises Sunset + Deprecation", () => {
+  beforeEach(() => {
+    versions.v2 = {
+      version: "v2",
+      status: "deprecated",
+      introducedAt: "2026-08-01",
+      deprecatedAt: "2026-08-15",
+      sunsetAt: "2027-08-15",
+      docsUrl: `${API_VERSIONING_POLICY_URL}#api-v2`,
+    };
+  });
+
+  afterEach(() => {
+    delete versions.v2;
+  });
+
+  it("emits Deprecation and Sunset headers for /api/v2", async () => {
+    const baseUrl = await startTransitionServer();
+    const response = await fetch(`${baseUrl}/api/v2/ping`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ pong: "v2" });
+    expect(response.headers.get("x-api-version")).toBe("v2");
+    expect(response.headers.get("deprecation")).toBe("true");
+    expect(response.headers.get("sunset")).toBe(
+      toHttpDate("2027-08-15"),
+    );
+    expect(response.headers.get("link")).toContain('rel="deprecation"');
+  });
+
+  it("appears in the deprecated version list", () => {
+    expect(isVersionDeprecated("v2")).toBe(true);
+    expect(listDeprecatedVersions()).toContain("v2");
+  });
+});


### PR DESCRIPTION
Closes #674

## Summary

All endpoints lived at the root `/api` namespace with no versioning or lifecycle policy, making breaking changes (e.g. response envelope, pagination meta) risky for consumers. This PR adopts URI versioning (`/api/vN`) and a published deprecation policy.

## What changed

- **Version registry** (`src/api/versioning/registry.ts`) — single source of truth for API versions, their lifecycle status (`active` / `deprecated`), and sunset dates. `v1` is active; the unversioned `/api` namespace is registered as a **deprecated legacy alias** forwarding to v1, sunset `2027-06-30`.
- **Versioning middleware** (`src/api/versioning/middleware.ts`) — emits `X-API-Version` on every request and `Deprecation` + `Sunset` + `Link` headers on deprecated surfaces. Idempotent, so it composes across app-level and router-level mounts.
- **Graceful legacy aliasing** — `/api/v1` remains the canonical versioned namespace; unversioned `/api/*` still resolves to v1 for the deprecation window, now advertising deprecation headers.
- **Policy docs** (`docs/API_VERSIONING.md`) — support window (>= 12 months after next major) and sunset cadence (>= 6 months notice), lifecycle states, how to add/deprecate a version.
- **Version-aware docs** — Swagger spec (`src/config/swagger.ts`) updated with versioning notes, policy link, and legacy server warning; README links the policy.

## Tests

`tests/api-versioning.test.ts` (17 tests):
- **Sniff test** asserting legacy `/api` responses stay stable against `/api/v1` for the deprecation window.
- Deprecated surfaces emit `Sunset` + `Deprecation` + `Link` headers; `/api/v1` does not.
- Concurrent `v1`/`v2` operation during a transition, plus a deprecated-v2 case.

`tsc --noEmit` passes; existing `opportunities-route-contract`, `health-route`, and `test-modular-routes` suites still pass.

## Notes

Unblocks consolidating the error envelope and pagination standard across versions.
