### PR TITLE
fix: prevent overlapping scheduler executions

### DIFF
--- a/src/services/schedulerRunner.ts
+++ b/src/services/schedulerRunner.ts
@@ -1,0 +1,154 @@
+export type SchedulerTask = () => void | Promise<void>;
+
+export interface NonOverlappingJobOptions {
+  name: string;
+  intervalMs: number;
+  task: SchedulerTask;
+  /**
+   * Allows timer-based execution in tests when explicitly requested.
+   * By default, start() is a no-op when NODE_ENV === "test".
+   */
+  allowInTest?: boolean;
+}
+
+export interface SchedulerJobStats {
+  name: string;
+  running: boolean;
+  startedAt: number | null;
+  completedAt: number | null;
+  durationMs: number | null;
+  skippedRuns: number;
+}
+
+export interface NonOverlappingJob {
+  start(): void;
+  stop(): void;
+  runNow(): Promise<boolean>;
+  getStats(): SchedulerJobStats;
+  getIntervalHandle(): NodeJS.Timeout | null;
+}
+
+export function createNonOverlappingJob(
+  options: NonOverlappingJobOptions,
+): NonOverlappingJob {
+  if (!options.name.trim()) {
+    throw new Error("Scheduler job name is required.");
+  }
+
+  if (!Number.isFinite(options.intervalMs) || options.intervalMs <= 0) {
+    throw new Error("Scheduler interval must be a positive number.");
+  }
+
+  let running = false;
+  let startedAt: number | null = null;
+  let completedAt: number | null = null;
+  let durationMs: number | null = null;
+  let skippedRuns = 0;
+  let intervalHandle: NodeJS.Timeout | null = null;
+
+  const runNow = async (): Promise<boolean> => {
+    if (running) {
+      skippedRuns += 1;
+      console.warn(
+        `[Scheduler:${options.name}] Skipping execution because the previous run is still active.`,
+      );
+      return false;
+    }
+
+    running = true;
+    startedAt = Date.now();
+    completedAt = null;
+    durationMs = null;
+
+    try {
+      await options.task();
+      return true;
+    } finally {
+      completedAt = Date.now();
+      durationMs = completedAt - (startedAt ?? completedAt);
+      running = false;
+    }
+  };
+
+  const tick = (): void => {
+    void runNow().catch((error) => {
+      console.error(`[Scheduler:${options.name}] Scheduled task failed:`, error);
+    });
+  };
+
+  const start = (): void => {
+    if (intervalHandle) return;
+
+    if (
+      process.env.NODE_ENV === "test" &&
+      options.allowInTest !== true
+    ) {
+      return;
+    }
+
+    intervalHandle = setInterval(tick, options.intervalMs);
+  };
+
+  const stop = (): void => {
+    if (!intervalHandle) return;
+    clearInterval(intervalHandle);
+    intervalHandle = null;
+  };
+
+  return {
+    start,
+    stop,
+    runNow,
+    getStats: () => ({
+      name: options.name,
+      running,
+      startedAt,
+      completedAt,
+      durationMs,
+      skippedRuns,
+    }),
+    getIntervalHandle: () => intervalHandle,
+  };
+}
+
+export function createDeadlineSchedulerJobs(
+  runDeadlineChecks: SchedulerTask,
+  runWeeklyDigest: SchedulerTask,
+  options: {
+    dailyIntervalMs: number;
+    weeklyIntervalMs: number;
+    allowInTest?: boolean;
+  },
+): {
+  deadlineJob: NonOverlappingJob;
+  weeklyDigestJob: NonOverlappingJob;
+  start(): void;
+  stop(): void;
+} {
+  const deadlineJob = createNonOverlappingJob({
+    name: "deadline-reminders",
+    intervalMs: options.dailyIntervalMs,
+    task: runDeadlineChecks,
+    allowInTest: options.allowInTest,
+  });
+
+  const weeklyDigestJob = createNonOverlappingJob({
+    name: "weekly-digest",
+    intervalMs: options.weeklyIntervalMs,
+    task: runWeeklyDigest,
+    allowInTest: options.allowInTest,
+  });
+
+  return {
+    deadlineJob,
+    weeklyDigestJob,
+    start() {
+      deadlineJob.start();
+      weeklyDigestJob.start();
+    },
+    stop() {
+      deadlineJob.stop();
+      weeklyDigestJob.stop();
+    },
+  };
+}

--- a/tests/scheduler-runner.test.ts
+++ b/tests/scheduler-runner.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createDeadlineSchedulerJobs,
+  createNonOverlappingJob,
+} from "../src/services/schedulerRunner";
+
+describe("createNonOverlappingJob", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("does not run the same task concurrently", async () => {
+    let resolveTask!: () => void;
+    let calls = 0;
+
+    const task = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          calls += 1;
+          resolveTask = resolve;
+        }),
+    );
+
+    const job = createNonOverlappingJob({
+      name: "deadline-reminders",
+      intervalMs: 10,
+      task,
+      allowInTest: true,
+    });
+
+    const firstRun = job.runNow();
+    expect(calls).toBe(1);
+
+    const secondRun = await job.runNow();
+    expect(secondRun).toBe(false);
+    expect(job.getStats().skippedRuns).toBe(1);
+    expect(calls).toBe(1);
+
+    resolveTask();
+    await firstRun;
+
+    expect(job.getStats().running).toBe(false);
+    expect(job.getStats().completedAt).not.toBeNull();
+    expect(job.getStats().durationMs).not.toBeNull();
+  });
+
+  it("resets running state after a task fails", async () => {
+    const job = createNonOverlappingJob({
+      name: "weekly-digest",
+      intervalMs: 1000,
+      task: async () => {
+        throw new Error("boom");
+      },
+    });
+
+    await expect(job.runNow()).rejects.toThrow("boom");
+    expect(job.getStats().running).toBe(false);
+    expect(job.getStats().completedAt).not.toBeNull();
+    expect(job.getStats().durationMs).not.toBeNull();
+  });
+
+  it("records skipped timer executions while a task is active", async () => {
+    vi.useFakeTimers();
+
+    let resolveTask!: () => void;
+    const task = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveTask = resolve;
+        }),
+    );
+
+    const job = createNonOverlappingJob({
+      name: "deadline-reminders",
+      intervalMs: 100,
+      task,
+      allowInTest: true,
+    });
+
+    job.start();
+    expect(job.getIntervalHandle()).not.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(task).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(task).toHaveBeenCalledTimes(1);
+    expect(job.getStats().skippedRuns).toBe(3);
+
+    resolveTask();
+    await vi.advanceTimersByTimeAsync(0);
+
+    job.stop();
+    expect(job.getIntervalHandle()).toBeNull();
+  });
+
+  it("can be stopped explicitly", () => {
+    vi.useFakeTimers();
+
+    const job = createNonOverlappingJob({
+      name: "deadline-reminders",
+      intervalMs: 100,
+      task: vi.fn(),
+      allowInTest: true,
+    });
+
+    job.start();
+    expect(job.getIntervalHandle()).not.toBeNull();
+
+    job.stop();
+    expect(job.getIntervalHandle()).toBeNull();
+
+    vi.advanceTimersByTime(500);
+    expect(job.getStats().skippedRuns).toBe(0);
+  });
+
+  it("does not start background timers in test mode by default", () => {
+    vi.useFakeTimers();
+
+    const job = createNonOverlappingJob({
+      name: "deadline-reminders",
+      intervalMs: 100,
+      task: vi.fn(),
+    });
+
+    job.start();
+
+    expect(job.getIntervalHandle()).toBeNull();
+  });
+});
+
+describe("createDeadlineSchedulerJobs", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps daily and weekly schedules independently configurable", () => {
+    const deadlineTask = vi.fn();
+    const weeklyTask = vi.fn();
+
+    const scheduler = createDeadlineSchedulerJobs(
+      deadlineTask,
+      weeklyTask,
+      {
+        dailyIntervalMs: 1000,
+        weeklyIntervalMs: 5000,
+        allowInTest: true,
+      },
+    );
+
+    expect(scheduler.deadlineJob.getStats().name).toBe("deadline-reminders");
+    expect(scheduler.weeklyDigestJob.getStats().name).toBe("weekly-digest");
+
+    scheduler.start();
+    expect(scheduler.deadlineJob.getIntervalHandle()).not.toBeNull();
+    expect(scheduler.weeklyDigestJob.getIntervalHandle()).not.toBeNull();
+
+    scheduler.stop();
+    expect(scheduler.deadlineJob.getIntervalHandle()).toBeNull();
+    expect(scheduler.weeklyDigestJob.getIntervalHandle()).toBeNull();
+  });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## Summary

Fixes #564 by adding a reusable non-overlapping scheduler runner for asynchronous scheduled jobs.

## Changes Made

- Added `createNonOverlappingJob()` in `src/services/schedulerRunner.ts`.
- Prevents the same async task from running concurrently.
- Records the running state, start time, completion time, duration, and skipped-run count.
- Uses `try/finally` to guarantee that the running state is reset after both success and failure.
- Provides explicit `start()` and `stop()` lifecycle methods.
- Exposes the interval handle for clean shutdown and inspection.
- Added `createDeadlineSchedulerJobs()` for independently configurable daily deadline and weekly digest schedules.
- Prevents background timers from starting automatically when `NODE_ENV === "test"`.
- Added Vitest coverage using fake timers.

## Acceptance Criteria

- [x] The same scheduled job cannot run concurrently in one process.
- [x] A skipped execution is recorded when the previous run is active.
- [x] Running state is reset after both success and failure.
- [x] Interval handles can be stopped explicitly.
- [x] No scheduler timers are started in test mode by default.
- [x] Daily and weekly schedules are independently configurable.
- [x] Tests use fake timers rather than real-time waits.
- [x] Tests cover successful execution.
- [x] Tests cover task failure.
- [x] Tests cover skipped executions.
- [x] Tests cover scheduler cleanup.
- [x] No frontend changes are required.

## Testing

Run:

```bash
npx vitest run tests/scheduler-runner.test.ts'
```

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [x] I have updated the documentation (if required).
- [x] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

❤️ Thank you for contributing!