### PR TITLE
fix: trigger admin alerts on RabbitMQ DLQ events (#604)

### DIFF
--- a/docs/RABBITMQ_DLQ_RECOVERY.md
+++ b/docs/RABBITMQ_DLQ_RECOVERY.md
@@ -69,10 +69,13 @@ Peeking messages from a DLQ allows inspecting failure details without destroying
 - **Admin API**: `GET /api/admin/dlq/inspect/:queueName?limit=10`
 - **Programmatic**:
   ```ts
-  const messages = await eventBus.inspectDlq("notification_queue", 10);
-  // Returns: [{ payload: {...}, headers: { "x-death-reason": "...", "x-death-timestamp": "..." }, routingKey: "..." }]
-  ```
+const messages = await eventBus.inspectDlq("notification_queue", 10);
+// Returns: [{ payload: {...}, headers: { "x-death-reason": "...", "x-death-timestamp": "..." }, routingKey: "..." }]
 
+### C. Proactive Alerts
+Whenever a message exhausts its retries and is routed to a DLQ, `EventBus` immediately triggers an admin email alert via the existing `sendAdminAlert` helper (the same one used for background job failures). No manual polling is required to learn that a message failed permanently — admins configured in `ADMIN_EMAILS` receive a notification with the queue name, routing key, and retry count.
+
+---
 ---
 
 ## 4. Replay & Recovery Workflow

--- a/src/events/eventBus.ts
+++ b/src/events/eventBus.ts
@@ -1,5 +1,5 @@
 import * as amqp from "amqplib";
-
+import { sendAdminAlert } from "../services/adminAlertService.js";
 const RABBITMQ_URL = process.env.RABBITMQ_URL || "amqp://localhost";
 
 const MAIN_EXCHANGE = "domain_events";
@@ -149,8 +149,12 @@ class EventBus {
             "x-original-routing-key": routingKey,
           };
           this.channel!.nack(msg, false, false);
-        }
-      }
+          sendAdminAlert(
+            "EventBus",
+            { id: msg.properties.messageId || queueName, data: { domain: routingKey }, attemptsMade: retries },
+            error,
+          );
+        }      }
     });
 
     console.log(`[EventBus] Subscribed to ${routingKey} via queue ${queueName} (DLX: ${DLX_EXCHANGE})`);


### PR DESCRIPTION
## Summary
Closes #604.

Investigated the codebase before making changes: the DLQ exchange, dead-letter
routing, per-queue configuration, admin inspection/replay/purge endpoints, and
recovery documentation were already implemented in eventBus.ts, adminController.ts,
adminRoutes.ts, and docs/RABBITMQ_DLQ_RECOVERY.md.

The one gap against the acceptance criteria was "Monitoring reports DLQ activity" -
monitoring was pull-only (someone had to call GET /api/admin/dlq/stats to notice a
failure). This PR wires the existing sendAdminAlert email-alert helper (already used
for BullMQ worker failures) into EventBus so a DLQ event now proactively notifies
admins by email, instead of requiring manual polling.

## Changes
- src/events/eventBus.ts: import sendAdminAlert and call it when a message is
  nacked to the DLQ after exhausting retries.
- docs/RABBITMQ_DLQ_RECOVERY.md: documented the new proactive alert behavior.

## Testing
- Existing tests (dlq-management.test.ts, eventBus-reliability.test.ts,
  test-eventbus.ts) cover DLQ routing/replay and were not touched.
- Recommend adding a small unit test that mocks sendAdminAlert and asserts it's
  called when a message is nacked to the DLQ (happy to add if desired).

Closes #604 

@uditt490-pixel 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.