### PR TITLE
feat: Add AI cache metrics tracking and admin endpoint (#591)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -15,6 +15,7 @@ import rateLimit from "express-rate-limit";
 import { RedisStore } from "rate-limit-redis";
 import Redis from "ioredis";
 import { v2 as cloudinary } from "cloudinary";
+import { AICacheMetrics } from "./src/api/services/aiCacheMetrics.js";
 
 dotenv.config();
 
@@ -1242,12 +1243,20 @@ async function startServer() {
   // In-memory cache for AI generation prompts and resume reviews
   const aiCache = new Map<string, { data: any; timestamp: number }>();
   const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+  const cacheMetrics = new AICacheMetrics();
 
   function getCachedResponse(key: string): any | null {
     const entry = aiCache.get(key);
     if (entry && (Date.now() - entry.timestamp < CACHE_TTL_MS)) {
+      cacheMetrics.recordHit();
       return entry.data;
     }
+    if (entry) {
+      // Entry expired — count as eviction and clean up
+      cacheMetrics.recordEviction();
+      aiCache.delete(key);
+    }
+    cacheMetrics.recordMiss();
     return null;
   }
 
@@ -1889,6 +1898,12 @@ Return JSON strictly in this format:
       fallbackRate: 2.1,
       apiLatency: 120
     });
+  });
+
+  // --- AI Cache Metrics ---
+  app.get("/api/v1/admin/cache-metrics", (_req, res) => {
+    const metrics = cacheMetrics.snapshot(aiCache);
+    res.json(metrics);
   });
 
   app.get("/api/v1/admin/scrapers", async (req, res) => {

--- a/src/api/services/aiCacheMetrics.ts
+++ b/src/api/services/aiCacheMetrics.ts
@@ -1,0 +1,121 @@
+/**
+ * AI Cache Metrics Service (Issue #591)
+ *
+ * Tracks performance metrics for the in-memory AI response cache:
+ * - Cache hits and misses
+ * - Hit ratio (hits / total lookups)
+ * - Current cache size (entry count)
+ * - Evictions (expired entries detected during lookup)
+ * - Approximate memory usage
+ */
+
+export interface CacheMetricsSnapshot {
+  hits: number;
+  misses: number;
+  totalLookups: number;
+  hitRatio: number;
+  cacheSize: number;
+  evictions: number;
+  estimatedMemoryBytes: number;
+  timestamp: string;
+}
+
+/**
+ * Lightweight in-memory tracker for AI cache metrics.
+ *
+ * Designed to be instantiated once and shared across the cache helpers.
+ * All methods are synchronous — no I/O or async required.
+ */
+export class AICacheMetrics {
+  private _hits = 0;
+  private _misses = 0;
+  private _evictions = 0;
+  private _startTime: number;
+
+  constructor() {
+    this._startTime = Date.now();
+  }
+
+  /** Record a cache hit. */
+  recordHit(): void {
+    this._hits++;
+  }
+
+  /** Record a cache miss. */
+  recordMiss(): void {
+    this._misses++;
+  }
+
+  /** Record an eviction (expired entry detected during lookup). */
+  recordEviction(): void {
+    this._evictions++;
+  }
+
+  /** Total number of cache lookups (hits + misses). */
+  get totalLookups(): number {
+    return this._hits + this._misses;
+  }
+
+  /** Hit ratio as a value between 0 and 1. Returns 0 if no lookups yet. */
+  get hitRatio(): number {
+    const total = this.totalLookups;
+    return total === 0 ? 0 : this._hits / total;
+  }
+
+  /**
+   * Take a snapshot of current metrics.
+   *
+   * @param cache - The underlying Map used for AI caching (to derive size and
+   *   approximate memory usage).
+   */
+  snapshot(cache: Map<string, unknown>): CacheMetricsSnapshot {
+    return {
+      hits: this._hits,
+      misses: this._misses,
+      totalLookups: this.totalLookups,
+      hitRatio: Math.round(this.hitRatio * 10000) / 10000, // 4 decimal places
+      cacheSize: cache.size,
+      evictions: this._evictions,
+      estimatedMemoryBytes: this._estimateMemory(cache),
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Reset all counters to zero. Useful for periodic roll-ups or testing.
+   */
+  reset(): void {
+    this._hits = 0;
+    this._misses = 0;
+    this._evictions = 0;
+    this._startTime = Date.now();
+  }
+
+  /**
+   * Rough estimation of the cache's memory footprint in bytes.
+   *
+   * This uses a heuristic: each entry's key length + serialized value length
+   * + a fixed per-entry overhead (8 bytes for Map bucket + 16 bytes for the
+   * value wrapper object). It is not exact but gives a useful order-of-
+   * magnitude indicator for dashboards.
+   */
+  private _estimateMemory(cache: Map<string, unknown>): number {
+    const ENTRY_OVERHEAD = 24; // Map bucket + { data, timestamp } wrapper
+    let bytes = 0;
+
+    for (const [key, value] of cache) {
+      bytes += key.length * 2; // JS strings are UTF-16
+      bytes += ENTRY_OVERHEAD;
+
+      // Approximate the serialized value size
+      try {
+        bytes += JSON.stringify(value).length * 2;
+      } catch {
+        // If value is not serializable, estimate 200 bytes
+        bytes += 400;
+      }
+    }
+
+    return bytes;
+  }
+}

--- a/tests/aiCacheMetrics.test.ts
+++ b/tests/aiCacheMetrics.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest";
+import { AICacheMetrics } from "../src/api/services/aiCacheMetrics";
+
+describe("AICacheMetrics", () => {
+  it("starts with zero counters", () => {
+    const metrics = new AICacheMetrics();
+    const cache = new Map<string, unknown>();
+
+    expect(metrics.totalLookups).toBe(0);
+    expect(metrics.hitRatio).toBe(0);
+
+    const snap = metrics.snapshot(cache);
+    expect(snap.hits).toBe(0);
+    expect(snap.misses).toBe(0);
+    expect(snap.totalLookups).toBe(0);
+    expect(snap.hitRatio).toBe(0);
+    expect(snap.cacheSize).toBe(0);
+    expect(snap.evictions).toBe(0);
+    expect(snap.estimatedMemoryBytes).toBe(0);
+  });
+
+  it("increments hits on recordHit", () => {
+    const metrics = new AICacheMetrics();
+
+    metrics.recordHit();
+    metrics.recordHit();
+    metrics.recordHit();
+
+    expect(metrics.totalLookups).toBe(3);
+  });
+
+  it("increments misses on recordMiss", () => {
+    const metrics = new AICacheMetrics();
+
+    metrics.recordMiss();
+    metrics.recordMiss();
+
+    expect(metrics.totalLookups).toBe(2);
+  });
+
+  it("increments evictions on recordEviction", () => {
+    const metrics = new AICacheMetrics();
+
+    metrics.recordEviction();
+    metrics.recordEviction();
+    metrics.recordEviction();
+
+    const snap = metrics.snapshot(new Map());
+    expect(snap.evictions).toBe(3);
+  });
+
+  it("computes hit ratio correctly", () => {
+    const metrics = new AICacheMetrics();
+
+    // 3 hits + 1 miss = 75% hit ratio
+    metrics.recordHit();
+    metrics.recordHit();
+    metrics.recordHit();
+    metrics.recordMiss();
+
+    expect(metrics.hitRatio).toBeCloseTo(0.75, 4);
+    expect(metrics.totalLookups).toBe(4);
+  });
+
+  it("returns 0 hit ratio when no lookups have occurred", () => {
+    const metrics = new AICacheMetrics();
+    expect(metrics.hitRatio).toBe(0);
+  });
+
+  it("reports cache size from the provided Map", () => {
+    const metrics = new AICacheMetrics();
+    const cache = new Map<string, unknown>();
+    cache.set("key1", { data: "value1", timestamp: Date.now() });
+    cache.set("key2", { data: "value2", timestamp: Date.now() });
+
+    const snap = metrics.snapshot(cache);
+    expect(snap.cacheSize).toBe(2);
+  });
+
+  it("estimates memory usage based on cache contents", () => {
+    const metrics = new AICacheMetrics();
+    const cache = new Map<string, unknown>();
+    cache.set("test-key", { data: "test value with some content", timestamp: Date.now() });
+
+    const snap = metrics.snapshot(cache);
+    expect(snap.estimatedMemoryBytes).toBeGreaterThan(0);
+  });
+
+  it("estimates higher memory for larger cache entries", () => {
+    const metrics = new AICacheMetrics();
+    const smallCache = new Map<string, unknown>();
+    smallCache.set("k", { data: "small" });
+
+    const largeCache = new Map<string, unknown>();
+    largeCache.set("k", {
+      data: "a".repeat(10000),
+      timestamp: Date.now(),
+    });
+
+    const smallSnap = metrics.snapshot(smallCache);
+    const largeSnap = metrics.snapshot(largeCache);
+
+    expect(largeSnap.estimatedMemoryBytes).toBeGreaterThan(
+      smallSnap.estimatedMemoryBytes,
+    );
+  });
+
+  it("includes a valid ISO timestamp in snapshot", () => {
+    const metrics = new AICacheMetrics();
+    const snap = metrics.snapshot(new Map());
+
+    expect(snap.timestamp).toBeDefined();
+    expect(new Date(snap.timestamp).toISOString()).toBe(snap.timestamp);
+  });
+
+  it("reset clears all counters", () => {
+    const metrics = new AICacheMetrics();
+
+    metrics.recordHit();
+    metrics.recordHit();
+    metrics.recordMiss();
+    metrics.recordEviction();
+
+    metrics.reset();
+
+    expect(metrics.totalLookups).toBe(0);
+    expect(metrics.hitRatio).toBe(0);
+
+    const snap = metrics.snapshot(new Map());
+    expect(snap.hits).toBe(0);
+    expect(snap.misses).toBe(0);
+    expect(snap.evictions).toBe(0);
+  });
+
+  it("snapshot hitRatio is rounded to 4 decimal places", () => {
+    const metrics = new AICacheMetrics();
+
+    // 1 hit + 3 misses = 0.25
+    metrics.recordHit();
+    metrics.recordMiss();
+    metrics.recordMiss();
+    metrics.recordMiss();
+
+    const snap = metrics.snapshot(new Map());
+    expect(snap.hitRatio).toBe(0.25);
+  });
+
+  it("handles many hits and misses without overflow", () => {
+    const metrics = new AICacheMetrics();
+
+    for (let i = 0; i < 100000; i++) {
+      metrics.recordHit();
+    }
+    for (let i = 0; i < 50000; i++) {
+      metrics.recordMiss();
+    }
+
+    expect(metrics.totalLookups).toBe(150000);
+    expect(metrics.hitRatio).toBeCloseTo(2 / 3, 4);
+  });
+
+  it("works with a cache that has a mix of entry types", () => {
+    const metrics = new AICacheMetrics();
+    const cache = new Map<string, unknown>();
+    cache.set("prompt-1", { data: "response text", timestamp: Date.now() });
+    cache.set("resume:abc", { score: 85, strengths: [] });
+    cache.set("analysis:xyz", { score: 72, missingKeywords: ["TypeScript"] });
+
+    const snap = metrics.snapshot(cache);
+    expect(snap.cacheSize).toBe(3);
+    expect(snap.estimatedMemoryBytes).toBeGreaterThan(0);
+  });
+});
+
+describe("AICacheMetrics endpoint", () => {
+  it("returns cache metrics as JSON with correct structure", async () => {
+    // We test the endpoint structure by importing the snapshot type
+    // and verifying the shape matches what the endpoint would return
+    const metrics = new AICacheMetrics();
+    metrics.recordHit();
+    metrics.recordHit();
+    metrics.recordMiss();
+
+    const cache = new Map<string, unknown>();
+    cache.set("test", { data: "value" });
+
+    const snapshot = metrics.snapshot(cache);
+
+    // Verify the snapshot has all expected fields
+    expect(snapshot).toHaveProperty("hits");
+    expect(snapshot).toHaveProperty("misses");
+    expect(snapshot).toHaveProperty("totalLookups");
+    expect(snapshot).toHaveProperty("hitRatio");
+    expect(snapshot).toHaveProperty("cacheSize");
+    expect(snapshot).toHaveProperty("evictions");
+    expect(snapshot).toHaveProperty("estimatedMemoryBytes");
+    expect(snapshot).toHaveProperty("timestamp");
+
+    // Verify types
+    expect(typeof snapshot.hits).toBe("number");
+    expect(typeof snapshot.misses).toBe("number");
+    expect(typeof snapshot.totalLookups).toBe("number");
+    expect(typeof snapshot.hitRatio).toBe("number");
+    expect(typeof snapshot.cacheSize).toBe("number");
+    expect(typeof snapshot.evictions).toBe("number");
+    expect(typeof snapshot.estimatedMemoryBytes).toBe("number");
+    expect(typeof snapshot.timestamp).toBe("string");
+  });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Summary

Adds performance metrics tracking for the AI response cache, giving maintainers visibility into cache effectiveness. A new admin endpoint exposes hit/miss ratios, cache size, evictions, and estimated memory usage.

## 🔗 Related Issue

Closes #591

## ✨ Changes Made

- **Created `src/api/services/aiCacheMetrics.ts`** — `AICacheMetrics` class that tracks:
  - Cache hits and misses (raw counters)
  - Hit ratio (hits / total lookups, rounded to 4 decimal places)
  - Cache size (current entry count)
  - Evictions (expired entries detected during lookup and cleaned up)
  - Estimated memory usage (heuristic based on key/value serialization)
  - Timestamped snapshots for dashboard consumption

- **Instrumented `server.ts` cache functions**:
  - `getCachedResponse` now calls `cacheMetrics.recordHit()` on hit, `cacheMetrics.recordMiss()` on miss, and `cacheMetrics.recordEviction()` + cleanup on expired entries
  - `setCachedResponse` unchanged (no metrics needed for writes)

- **Added `GET /api/v1/admin/cache-metrics`** endpoint returning a JSON snapshot:
  ```json
  {
    "hits": 42,
    "misses": 18,
    "totalLookups": 60,
    "hitRatio": 0.7,
    "cacheSize": 35,
    "evictions": 3,
    "estimatedMemoryBytes": 128400,
    "timestamp": "2026-08-29T12:00:00.000Z"
  }
  ```

- **Added `tests/aiCacheMetrics.test.ts`** — 15 tests covering all metrics functionality

### Design Decisions

- **Lightweight class** — no I/O, no async, no external dependencies. All methods are synchronous.
- **Dependency injection** — `snapshot()` accepts the cache Map, keeping the class decoupled from the specific cache implementation.
- **Eviction detection** — expired entries are detected lazily during `getCachedResponse` and cleaned up, which avoids a background sweep while still tracking evictions.
- **Memory estimation** — uses a heuristic (key length + JSON-serialized value length + per-entry overhead) for an order-of-magnitude indicator, not exact measurement.
- **Non-blocking** — all tracking is in-memory counter increments with negligible overhead.

## 🧪 Testing

- [x] Tested locally — all 15 cache metrics tests pass
- [x] Added/updated tests — 15 new test cases covering all metrics functionality
- [x] Health service tests still pass (20/20)

### Test Coverage

| Area | Tests |
|---|---|
| Zero-initialization | 1 test |
| Hit/miss counting | 3 tests |
| Eviction tracking | 1 test |
| Hit ratio computation | 2 tests |
| Cache size reporting | 1 test |
| Memory estimation | 3 tests |
| Snapshot structure | 2 tests |
| Reset functionality | 1 test |
| Scale/overflow | 1 test |

## ✅ Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [x] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

❤️ Thank you for contributing!