### PR TITLE
feat: implement reusable focus trap and integrate into ShareModal for…

### DIFF
--- a/src/components/LandingNavbar.tsx
+++ b/src/components/LandingNavbar.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Zap, Sun, Moon, Menu, X, ArrowLeft } from 'lucide-react';
 import { useAppContext } from '../context/AppContext';
+import ThemeToggle from './ThemeToggle';
 
 interface LandingNavbarProps {
   /** Called when the user clicks Login */
@@ -26,7 +27,7 @@ function scrollToSection(id: string) {
 }
 
 export default function LandingNavbar({ onLoginClick, onNavClick }: LandingNavbarProps) {
-  const { activeTab, setActiveTab, theme, toggleTheme } = useAppContext();
+  const { activeTab, setActiveTab } = useAppContext();
   const [mobileOpen, setMobileOpen] = useState(false);
 
   const handleNavClick = (e: React.MouseEvent<HTMLAnchorElement>, href: string) => {
@@ -45,7 +46,7 @@ export default function LandingNavbar({ onLoginClick, onNavClick }: LandingNavba
   };
 
   return (
-    <header className="sticky top-0 z-50 bg-[#fcf9f2]/90 backdrop-blur-md border-b border-[#e8ded1] transition-colors duration-300">
+    <header className="sticky top-0 z-50 bg-navbar/90 backdrop-blur-md border-b border-border-theme transition-colors duration-300">
       <div className="max-w-7xl mx-auto h-[72px] px-6 lg:px-12 flex items-center justify-between">
         
         {/* Brand Mark */}
@@ -56,23 +57,23 @@ export default function LandingNavbar({ onLoginClick, onNavClick }: LandingNavba
             window.scrollTo({ top: 0, behavior: 'smooth' });
           }}
         >
-          <div className="w-9 h-9 rounded-full bg-[#603620] flex items-center justify-center shadow-md">
+          <div className="w-9 h-9 rounded-full bg-search-btn flex items-center justify-center shadow-md">
             <Zap className="w-4 h-4 text-[#f3e4bd]" />
           </div>
-          <span className="font-serif font-bold text-2xl tracking-tight text-[#231f20]">
-            Yuva<span className="text-[#b56b37] italic">Hub</span>
+          <span className="font-serif font-bold text-2xl tracking-tight text-text-primary">
+            Yuva<span className="text-primary-blue italic">Hub</span>
           </span>
         </div>
 
         {/* Desktop Nav Links or Back Button */}
         {activeTab === 'dashboard' ? (
-          <nav className="hidden md:flex items-center gap-10 text-xs uppercase tracking-widest font-bold text-[#603620]">
+          <nav className="hidden md:flex items-center gap-10 text-xs uppercase tracking-widest font-bold text-text-secondary">
             {NAV_LINKS.map((link) => (
               <a
                 key={link.href}
                 href={`#${link.href}`}
                 onClick={(e) => handleNavClick(e, link.href)}
-                className="hover:text-[#b56b37] transition-colors cursor-pointer"
+                className="hover:text-primary-blue transition-colors cursor-pointer"
               >
                 {link.label}
               </a>
@@ -84,7 +85,7 @@ export default function LandingNavbar({ onLoginClick, onNavClick }: LandingNavba
               setActiveTab('dashboard');
               window.scrollTo({ top: 0, behavior: 'smooth' });
             }}
-            className="flex items-center gap-2 text-xs font-extrabold uppercase tracking-wider text-[#b56b37] hover:text-[#603620] transition-colors bg-transparent border-none cursor-pointer"
+            className="flex items-center gap-2 text-xs font-extrabold uppercase tracking-wider text-primary-blue hover:text-text-primary transition-colors bg-transparent border-none cursor-pointer"
           >
             <ArrowLeft className="w-4 h-4" /> Back to Home
           </button>
@@ -92,17 +93,22 @@ export default function LandingNavbar({ onLoginClick, onNavClick }: LandingNavba
 
         {/* Actions */}
         <div className="flex items-center gap-3">
+          
+          {/* Desktop Theme Toggle */}
+          <div className="hidden md:block">
+            <ThemeToggle />
+          </div>
 
           <button
             onClick={onLoginClick}
-            className="hidden md:block px-6 py-2.5 text-xs font-extrabold uppercase tracking-wider bg-[#b56b37] text-white rounded-full shadow-md hover:bg-[#603620] transition-all cursor-pointer"
+            className="hidden md:block px-6 py-2.5 text-xs font-extrabold uppercase tracking-wider bg-primary-blue text-white rounded-full shadow-md hover:opacity-90 transition-all cursor-pointer"
           >
             Sign In
           </button>
 
           {/* Mobile Hamburger */}
           <button
-            className="md:hidden p-2 text-[#603620] rounded-xl hover:bg-[#f3e4bd]/50"
+            className="md:hidden p-2 text-text-secondary rounded-xl hover:bg-surface-secondary"
             onClick={() => setMobileOpen((prev) => !prev)}
             aria-label="Toggle Menu"
           >
@@ -113,14 +119,21 @@ export default function LandingNavbar({ onLoginClick, onNavClick }: LandingNavba
 
       {/* Mobile Menu */}
       {mobileOpen && (
-        <div className="md:hidden bg-[#fcf9f2] border-b border-[#e8ded1] shadow-xl px-6 py-6 flex flex-col gap-4">
+        <div className="md:hidden bg-navbar border-b border-border-theme shadow-xl px-6 py-6 flex flex-col gap-4">
+          
+          {/* Mobile Theme Toggle */}
+          <div className="flex justify-between items-center pb-4 border-b border-border-theme/50">
+            <span className="text-sm font-bold uppercase tracking-wider text-text-secondary">Theme</span>
+            <ThemeToggle />
+          </div>
+
           {activeTab === 'dashboard' ? (
             NAV_LINKS.map((link) => (
               <a
                 key={link.href}
                 href={`#${link.href}`}
                 onClick={(e) => handleNavClick(e, link.href)}
-                className="text-sm font-bold uppercase tracking-wider text-[#603620] hover:text-[#b56b37]"
+                className="text-sm font-bold uppercase tracking-wider text-text-secondary hover:text-primary-blue"
               >
                 {link.label}
               </a>
@@ -132,14 +145,14 @@ export default function LandingNavbar({ onLoginClick, onNavClick }: LandingNavba
                 setActiveTab('dashboard');
                 window.scrollTo({ top: 0, behavior: 'smooth' });
               }}
-              className="text-sm font-bold uppercase tracking-wider text-[#b56b37] flex items-center gap-2"
+              className="text-sm font-bold uppercase tracking-wider text-primary-blue flex items-center gap-2"
             >
               <ArrowLeft className="w-4 h-4" /> Back to Home
             </button>
           )}
           <button
             onClick={() => { setMobileOpen(false); onLoginClick(); }}
-            className="mt-2 w-full py-3 text-xs font-extrabold uppercase tracking-wider bg-[#b56b37] text-white rounded-full shadow-md text-center"
+            className="mt-2 w-full py-3 text-xs font-extrabold uppercase tracking-wider bg-primary-blue text-white rounded-full shadow-md text-center"
           >
             Sign In / Register
           </button>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,54 @@
+import { useTheme } from '../context/ThemeContext';
+
+const ThemeToggle = () => {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <div 
+      className="flex items-center space-x-1 bg-surface-secondary border border-border-theme p-1 rounded-lg"
+      role="group"
+      aria-label="Theme Preferences"
+    >
+      <button
+        onClick={() => setTheme('light')}
+        className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-focus-ring ${
+          theme === 'light' 
+            ? 'bg-surface shadow-sm text-primary-blue' 
+            : 'text-text-secondary hover:text-text-primary'
+        }`}
+        aria-pressed={theme === 'light'}
+        aria-label="Enable light mode"
+      >
+        Light
+      </button>
+      
+      <button
+        onClick={() => setTheme('dark')}
+        className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-focus-ring ${
+          theme === 'dark' 
+            ? 'bg-surface shadow-sm text-primary-blue' 
+            : 'text-text-secondary hover:text-text-primary'
+        }`}
+        aria-pressed={theme === 'dark'}
+        aria-label="Enable dark mode"
+      >
+        Dark
+      </button>
+
+      <button
+        onClick={() => setTheme('system')}
+        className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-focus-ring ${
+          theme === 'system' 
+            ? 'bg-surface shadow-sm text-primary-blue' 
+            : 'text-text-secondary hover:text-text-primary'
+        }`}
+        aria-pressed={theme === 'system'}
+        aria-label="Enable system default theme"
+      >
+        System
+      </button>
+    </div>
+  );
+};
+
+export default ThemeToggle;

--- a/src/components/ui/ShareModal.tsx
+++ b/src/components/ui/ShareModal.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import { X, Twitter, Linkedin, MessageCircle, Copy, Check } from 'lucide-react';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 interface ShareModalProps {
   isOpen: boolean;
@@ -11,55 +12,8 @@ export default function ShareModal({ isOpen, onClose, opportunity }: ShareModalP
   const [copied, setCopied] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const previousFocus = document.activeElement as HTMLElement;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-        return;
-      }
-
-      if (e.key === 'Tab' && modalRef.current) {
-        const focusableElements = modalRef.current.querySelectorAll(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        ) as NodeListOf<HTMLElement>;
-
-        if (focusableElements.length === 0) return;
-
-        const firstElement = focusableElements[0];
-        const lastElement = focusableElements[focusableElements.length - 1];
-
-        if (e.shiftKey) {
-          if (document.activeElement === firstElement) {
-            lastElement.focus();
-            e.preventDefault();
-          }
-        } else {
-          if (document.activeElement === lastElement) {
-            firstElement.focus();
-            e.preventDefault();
-          }
-        }
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-
-    if (modalRef.current) {
-      const focusable = modalRef.current.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])') as NodeListOf<HTMLElement>;
-      if (focusable.length > 0) {
-        focusable[0].focus();
-      }
-    }
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      previousFocus?.focus();
-    };
-  }, [isOpen, onClose]);
+  // The custom hook handles all the complex keyboard trapping logic now!
+  useFocusTrap(modalRef, isOpen, onClose);
 
   if (!isOpen || !opportunity) return null;
 
@@ -79,30 +33,35 @@ export default function ShareModal({ isOpen, onClose, opportunity }: ShareModalP
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-gray-900/50 backdrop-blur-sm">
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
       <div 
         ref={modalRef}
+        tabIndex={-1}
         role="dialog"
         aria-modal="true"
         aria-labelledby="share-modal-title"
-        className="bg-white rounded-xl shadow-xl w-full max-w-sm overflow-hidden animate-in fade-in zoom-in-95 duration-200"
+        className="bg-surface border border-border-theme rounded-xl shadow-xl w-full max-w-sm overflow-hidden animate-in fade-in zoom-in-95 duration-200 outline-none"
       >
-        <div className="p-4 border-b border-gray-100 flex justify-between items-center bg-gray-50/50">
-          <h3 id="share-modal-title" className="font-semibold text-gray-900">Share Opportunity</h3>
-          <button onClick={onClose} className="p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors">
+        <div className="p-4 border-b border-border-theme flex justify-between items-center bg-surface-secondary">
+          <h3 id="share-modal-title" className="font-semibold text-text-primary">Share Opportunity</h3>
+          <button 
+            onClick={onClose} 
+            className="p-1 text-text-secondary hover:text-text-primary hover:bg-surface rounded-lg transition-colors"
+            aria-label="Close modal"
+          >
             <X className="w-5 h-5" />
           </button>
         </div>
         
         <div className="p-5">
-          <p className="text-sm font-medium text-gray-700 mb-4 line-clamp-2">{opportunity.title}</p>
+          <p className="text-sm font-medium text-text-secondary mb-4 line-clamp-2">{opportunity.title}</p>
           
           <div className="grid grid-cols-3 gap-3 mb-6">
             <a 
               href={links.linkedin} 
               target="_blank" 
               rel="noopener noreferrer"
-              className="flex flex-col items-center gap-2 p-3 rounded-lg hover:bg-blue-50 text-blue-700 transition-colors border border-transparent hover:border-blue-100"
+              className="flex flex-col items-center gap-2 p-3 rounded-lg hover:bg-surface-secondary text-text-primary transition-colors border border-transparent hover:border-border-theme"
             >
               <div className="w-10 h-10 rounded-full bg-[#0077b5] flex items-center justify-center text-white">
                 <Linkedin className="w-5 h-5" fill="currentColor" />
@@ -114,7 +73,7 @@ export default function ShareModal({ isOpen, onClose, opportunity }: ShareModalP
               href={links.twitter} 
               target="_blank" 
               rel="noopener noreferrer"
-              className="flex flex-col items-center gap-2 p-3 rounded-lg hover:bg-sky-50 text-sky-700 transition-colors border border-transparent hover:border-sky-100"
+              className="flex flex-col items-center gap-2 p-3 rounded-lg hover:bg-surface-secondary text-text-primary transition-colors border border-transparent hover:border-border-theme"
             >
               <div className="w-10 h-10 rounded-full bg-[#1DA1F2] flex items-center justify-center text-white">
                 <Twitter className="w-5 h-5" fill="currentColor" />
@@ -126,7 +85,7 @@ export default function ShareModal({ isOpen, onClose, opportunity }: ShareModalP
               href={links.whatsapp} 
               target="_blank" 
               rel="noopener noreferrer"
-              className="flex flex-col items-center gap-2 p-3 rounded-lg hover:bg-green-50 text-green-700 transition-colors border border-transparent hover:border-green-100"
+              className="flex flex-col items-center gap-2 p-3 rounded-lg hover:bg-surface-secondary text-text-primary transition-colors border border-transparent hover:border-border-theme"
             >
               <div className="w-10 h-10 rounded-full bg-[#25D366] flex items-center justify-center text-white">
                 <MessageCircle className="w-5 h-5" fill="currentColor" />
@@ -136,22 +95,22 @@ export default function ShareModal({ isOpen, onClose, opportunity }: ShareModalP
           </div>
 
           <div className="relative">
-            <div className="flex items-center gap-2 p-2 bg-gray-50 border border-gray-200 rounded-lg">
+            <div className="flex items-center gap-2 p-2 bg-background border border-border-theme rounded-lg">
               <input 
                 type="text" 
                 readOnly 
                 value={shareUrl}
-                className="flex-1 bg-transparent border-none text-sm text-gray-600 focus:outline-none"
+                className="flex-1 bg-transparent border-none text-sm text-text-primary focus:outline-none"
               />
               <button 
                 onClick={handleCopy}
-                className="p-1.5 bg-white border border-gray-200 rounded-md text-gray-600 hover:text-blue-600 hover:border-blue-200 transition-colors"
+                className="p-1.5 bg-surface border border-border-theme rounded-md text-text-secondary hover:text-primary-blue hover:border-primary-blue transition-colors"
                 title="Copy link"
               >
-                {copied ? <Check className="w-4 h-4 text-green-600" /> : <Copy className="w-4 h-4" />}
+                {copied ? <Check className="w-4 h-4 text-green-500" /> : <Copy className="w-4 h-4" />}
               </button>
             </div>
-            {copied && <span className="absolute -top-7 right-0 text-[10px] bg-gray-800 text-white px-2 py-1 rounded">Copied!</span>}
+            {copied && <span className="absolute -top-7 right-0 text-[10px] bg-text-primary text-surface px-2 py-1 rounded">Copied!</span>}
           </div>
         </div>
       </div>

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -1,0 +1,53 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('theme') || 'system';
+    }
+    return 'system';
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    
+    const applyTheme = (currentTheme) => {
+      root.classList.remove('light', 'dark');
+      
+      if (currentTheme === 'system') {
+        const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        root.classList.add(systemTheme);
+      } else {
+        root.classList.add(currentTheme);
+      }
+    };
+
+    applyTheme(theme);
+    localStorage.setItem('theme', theme);
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleSystemChange = () => {
+      if (theme === 'system') applyTheme('system');
+    };
+    
+    mediaQuery.addEventListener('change', handleSystemChange);
+    return () => mediaQuery.removeEventListener('change', handleSystemChange);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};
+

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -14,7 +14,7 @@ const FOCUSABLE_SELECTORS =
  * - Calls `onClose` when the Escape key is pressed.
  */
 export function useFocusTrap(
-  containerRef: RefObject<HTMLElement | null>,
+  containerRef: RefObject<HTMLElement>,
   isOpen: boolean,
   onClose: () => void,
 ): void {
@@ -28,7 +28,13 @@ export function useFocusTrap(
       if (!containerRef.current) return;
       const focusable = containerRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
       const firstFocusable = Array.from(focusable).find(el => el.offsetParent !== null);
-      (firstFocusable ?? containerRef.current).focus();
+      
+      if (firstFocusable) {
+        firstFocusable.focus();
+      } else {
+        // Fallback: focus the container itself (ensure container has tabIndex={-1})
+        containerRef.current.focus();
+      }
     });
 
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -67,7 +73,9 @@ export function useFocusTrap(
       cancelAnimationFrame(raf);
       document.removeEventListener('keydown', handleKeyDown);
       // Restore focus to whatever was focused before the modal opened.
-      previouslyFocused?.focus();
+      if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+        previouslyFocused.focus();
+      }
     };
   }, [isOpen, onClose, containerRef]);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 @import "tailwindcss";
-@custom-variant dark (&:where(.dark, .dark *));
+
+/* Enable class-based dark mode in Tailwind v4 */
+@custom-variant dark (&:is(.dark *));
+
 @theme {
   --color-primary: var(--primary-blue);
   --color-primary-light: #EFF6FF;
@@ -105,20 +108,21 @@
   }
 }
 
+/* Updated Utilities to respect Dark Mode variables */
 @utility clean-card {
-  @apply bg-white border border-[var(--color-border)] rounded-xl shadow-sm overflow-hidden transition-all duration-300 ease-out hover:shadow-md hover:border-gray-300;
+  @apply bg-surface border border-border-theme rounded-xl shadow-sm overflow-hidden transition-all duration-300 ease-out hover:shadow-md;
 }
 
 @utility clean-btn {
-  @apply bg-[var(--color-primary)] text-white font-medium rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed;
+  @apply bg-primary-blue text-white font-medium rounded-lg hover:opacity-90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed;
 }
 
 @utility clean-btn-outline {
-  @apply bg-white text-[var(--color-primary)] border border-[var(--color-primary)] font-medium rounded-lg hover:bg-[var(--color-primary-light)] transition-colors disabled:opacity-50;
+  @apply bg-surface text-primary-blue border border-primary-blue font-medium rounded-lg hover:bg-surface-secondary transition-colors disabled:opacity-50;
 }
 
 @utility clean-input {
-  @apply bg-white border border-[var(--color-border)] text-gray-900 rounded-lg focus:ring-2 focus:ring-[var(--color-primary)] focus:border-transparent outline-none transition-all;
+  @apply bg-surface border border-border-theme text-text-primary rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent outline-none transition-all;
 }
 
 @keyframes karma-bounce {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import PublicPortfolio from './pages/PublicPortfolio.tsx';
 import CustomCursor from './components/CustomCursor.tsx';
 import { AppProvider } from './context/AppContext.tsx';
 import { SocketProvider } from './context/SocketContext.tsx';
+import { ThemeProvider } from './context/ThemeContext';
 import './index.css';
 import * as Sentry from "@sentry/react";
 
@@ -25,16 +26,18 @@ const isPublicPortfolio = window.location.pathname.startsWith('/p/');
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    {isPublicPortfolio ? (
-      <PublicPortfolio />
-    ) : (
-      <AppProvider>
-        <SocketProvider>
-          <CustomCursor />
-          <App />
-        </SocketProvider>
-      </AppProvider>
-    )}
+    <ThemeProvider>
+      {isPublicPortfolio ? (
+        <PublicPortfolio />
+      ) : (
+        <AppProvider>
+          <SocketProvider>
+            <CustomCursor />
+            <App />
+          </SocketProvider>
+        </AppProvider>
+      )}
+    </ThemeProvider>
   </StrictMode>,
 );
 
@@ -49,4 +52,3 @@ if ('serviceWorker' in navigator) {
       });
   });
 }
-


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Summary
This PR introduces a native Dark Mode across the platform and significantly overhauls accessibility (a11y) for keyboard users. It implements a persistent theme switcher and adds a robust focus management hook to trap keyboard focus inside modals, preventing users from tabbing into the background navigation.

---

## 🔗 Related Issue
Closes #928

---

## ✨ Changes Made
- Configured Tailwind v4 with dynamic CSS variables to support class-based dark mode.
- Built a `ThemeContext` provider to persist the user's light/dark/system preference in local storage.
- Created a `ThemeToggle` UI component and integrated it into both the desktop and mobile `LandingNavbar`.
- Implemented a reusable `useFocusTrap` React hook to handle `Tab` and `Shift+Tab` wrapping, as well as `Escape` key support for closing modals.
- Refactored `ShareModal` to utilize the new focus trap and updated its hardcoded colors to adapt to the new dynamic theme variables.

---

## 🧪 Testing
- [x] Tested locally
- [ ] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)

---

## 📸 Screenshots
N/A

---

## ✅ Checklist
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [ ] I have updated the documentation (if required).
- [ ] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---

❤️ Thank you for contributing!