### PR TITLE
Add Zod validation middleware for request handling

### DIFF
--- a/src/middleware/validate.ts
+++ b/src/middleware/validate.ts
@@ -1,0 +1,47 @@
+/**
+ * src/middleware/validate.ts
+ * --------------------------
+ * Robust Zod request validation middleware supporting req.body, req.params, and req.query,
+ * with sanitized error responses to prevent exposing internal field structures.
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { ZodError, ZodSchema } from 'zod';
+
+interface ValidationSchema {
+  body?: ZodSchema<any>;
+  params?: ZodSchema<any>;
+  query?: ZodSchema<any>;
+}
+
+export const validateRequest = (schema: ValidationSchema) => {
+  return async (req: Request, res: Response, next: NextFunction): Promise<any> => {
+    try {
+      if (schema.body) {
+        req.body = await schema.body.parseAsync(req.body);
+      }
+      if (schema.params) {
+        req.params = await schema.params.parseAsync(req.params);
+      }
+      if (schema.query) {
+        req.query = await schema.query.parseAsync(req.query);
+      }
+      return next();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        // Sanitize error response to prevent exposing internal field names and schema details
+        return res.status(400).json({
+          success: false,
+          error: 'Invalid request parameters or payload.',
+          details: error.errors.map((e) => ({
+            message: e.message,
+          })),
+        });
+      }
+      return res.status(500).json({
+        success: false,
+        error: 'Internal Server Error during validation.',
+      });
+    }
+  };
+};


### PR DESCRIPTION
## Description
This pull request addresses [Issue #377](https://github.com/uditt490-pixel/YuvaHub/issues/377) in [YuvaHub](https://github.com/uditt490-pixel/YuvaHub) by refactoring the Zod request validation middleware to validate `req.body`, `req.params`, and `req.query`, while sanitizing error responses to prevent exposing internal schema field names.

## Changes
* Created/Updated `src/middleware/validate.ts` to support multi-part request validation (`body`, `params`, `query`).
* Implemented error sanitization returning generic error headers paired with structured messages to protect internal data models.
* Ensured consistent middleware utility hooks for route mounting across application routers.

## Acceptance Criteria Checklist
- [x] Validate `req.body`, `req.params`, and `req.query` to block common injection vectors.
- [x] Prevent internal field name exposure by sanitizing raw Zod error messages in 400 responses.
- [x] Provide a consistent validation middleware wrapper for route mounting.

