### PR TITLE
Feature/application note workspace

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -24,6 +24,7 @@ import { authMiddleware } from "./src/api/middlewares/auth.js";
 import { requestExport, getExportHistory } from "./src/api/controllers/exportController.js";
 import { logStartupHealthReport } from "./src/api/services/healthService.js";
 import { AICacheMetrics } from "./src/api/services/aiCacheMetrics.js";
+import { applicationNoteInputSchema } from "./src/models/applicationNoteSchema.js";
 import { securityPipeline } from "./src/api/middlewares/security/index.js";
 import { shutdownGuard } from "./src/api/middlewares/security/shutdownGuard.js";
 
@@ -577,6 +578,25 @@ process.on("SIGBREAK", () => gracefulShutdown("SIGBREAK"));
 
 export let io: Server;
 
+// Parse a Mongo id route param, falling back to the raw string for mock DBs
+// or ids that are not valid ObjectIds.
+function parseNoteId(raw: string | string[]): any {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  try {
+    return new ObjectId(value);
+  } catch {
+    return value;
+  }
+}
+
+// A user may read/write a note's body if they own it or it was shared with them.
+// Sharing management and deletion are restricted to the owner separately.
+function canAccessNote(note: any, uid: string): boolean {
+  if (!note || !uid) return false;
+  if (note.ownerId === uid) return true;
+  return Array.isArray(note.sharedWith) && note.sharedWith.includes(uid);
+}
+
 export async function createApp() {
   const app = express();
   app.use(requestLogger);
@@ -734,6 +754,159 @@ export async function createApp() {
   // --- Export Routes ---
   app.post("/api/v1/export/request", authMiddleware, requestExport);
   app.get("/api/v1/export/history", authMiddleware, getExportHistory);
+
+  // --- Application Note Workspace -------------------------------------------
+  // Structured, block-based notes attached to a tracked application. Blocks can
+  // be text, checklists, links or reminders. Notes can be shared with other
+  // registered users, and edits broadcast in real time via the Socket.IO
+  // "note:*" events registered further down in this file.
+
+  // Fetch the workspace note for a tracked application (owner or shared users).
+  app.get("/api/v1/application-notes/:applicationId", authMiddleware, async (req, res) => {
+    try {
+      if (!db) return res.status(503).json({ error: "Database not available" });
+      const uid = req.user?.uid || req.user?.firebaseUid;
+      if (!uid) return res.status(401).json({ error: "Unauthorized" });
+
+      const { applicationId } = req.params;
+      const note = await db.collection("application_notes").findOne({ applicationId });
+
+      if (!note) return res.json({ note: null });
+      if (!canAccessNote(note, uid)) {
+        return res.status(403).json({ error: "You do not have access to this note" });
+      }
+
+      note.id = note._id?.toString?.() || note.id;
+      res.json({ note });
+    } catch (err) {
+      console.error("[ApplicationNotes] GET error:", err);
+      res.status(500).json({ error: "Internal Server Error" });
+    }
+  });
+
+  // Create the note on first save, or update its body (title + blocks) after.
+  app.post("/api/v1/application-notes", authMiddleware, async (req, res) => {
+    try {
+      if (!db) return res.status(503).json({ error: "Database not available" });
+      const uid = req.user?.uid || req.user?.firebaseUid;
+      if (!uid) return res.status(401).json({ error: "Unauthorized" });
+
+      const parsed = applicationNoteInputSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({
+          error: parsed.error.issues.map((i: any) => i.message).join(", "),
+        });
+      }
+      const { applicationId, title, blocks } = parsed.data;
+      const now = new Date();
+
+      const existing = await db.collection("application_notes").findOne({ applicationId });
+
+      if (existing) {
+        if (!canAccessNote(existing, uid)) {
+          return res.status(403).json({ error: "You do not have access to this note" });
+        }
+        const update: any = { updatedAt: now };
+        if (title !== undefined) update.title = title;
+        if (blocks !== undefined) update.blocks = blocks;
+
+        await db.collection("application_notes").updateOne({ _id: existing._id }, { $set: update });
+        const note = await db.collection("application_notes").findOne({ _id: existing._id });
+        note.id = note._id?.toString?.() || note.id;
+        return res.json({ note });
+      }
+
+      const doc: any = {
+        ownerId: uid,
+        applicationId,
+        title: title || "Application Workspace",
+        blocks: blocks || [],
+        sharedWith: [],
+        createdAt: now,
+        updatedAt: now,
+      };
+      const result = await db.collection("application_notes").insertOne(doc);
+      res.status(201).json({
+        note: { ...doc, id: result.insertedId?.toString?.() || result.insertedId },
+      });
+    } catch (err) {
+      console.error("[ApplicationNotes] POST error:", err);
+      res.status(500).json({ error: "Internal Server Error" });
+    }
+  });
+
+  // Owner only: add a collaborator by email or user id, or remove one.
+  app.patch("/api/v1/application-notes/:id/share", authMiddleware, async (req, res) => {
+    try {
+      if (!db) return res.status(503).json({ error: "Database not available" });
+      const uid = req.user?.uid || req.user?.firebaseUid;
+      if (!uid) return res.status(401).json({ error: "Unauthorized" });
+
+      const noteId = parseNoteId(req.params.id);
+      const note = await db.collection("application_notes").findOne({ _id: noteId });
+      if (!note) return res.status(404).json({ error: "Note not found" });
+      if (note.ownerId !== uid) {
+        return res.status(403).json({ error: "Only the note owner can manage sharing" });
+      }
+
+      const { addEmail, addUserId, removeUserId } = req.body || {};
+      let sharedWith: string[] = Array.isArray(note.sharedWith) ? [...note.sharedWith] : [];
+
+      if (addUserId && addUserId !== note.ownerId && !sharedWith.includes(addUserId)) {
+        sharedWith.push(addUserId);
+      }
+
+      if (addEmail) {
+        const target = await db.collection("users").findOne({
+          email: String(addEmail).toLowerCase().trim(),
+        });
+        const targetUid = target?.uid || target?.firebaseUid;
+        if (!targetUid) {
+          return res.status(404).json({ error: "No registered user with that email" });
+        }
+        if (targetUid !== note.ownerId && !sharedWith.includes(targetUid)) {
+          sharedWith.push(targetUid);
+        }
+      }
+
+      if (removeUserId) {
+        sharedWith = sharedWith.filter((u) => u !== removeUserId);
+      }
+
+      await db.collection("application_notes").updateOne(
+        { _id: note._id },
+        { $set: { sharedWith, updatedAt: new Date() } }
+      );
+      const updated = await db.collection("application_notes").findOne({ _id: note._id });
+      updated.id = updated._id?.toString?.() || updated.id;
+      res.json({ note: updated });
+    } catch (err) {
+      console.error("[ApplicationNotes] SHARE error:", err);
+      res.status(500).json({ error: "Internal Server Error" });
+    }
+  });
+
+  // Owner only: delete the note.
+  app.delete("/api/v1/application-notes/:id", authMiddleware, async (req, res) => {
+    try {
+      if (!db) return res.status(503).json({ error: "Database not available" });
+      const uid = req.user?.uid || req.user?.firebaseUid;
+      if (!uid) return res.status(401).json({ error: "Unauthorized" });
+
+      const noteId = parseNoteId(req.params.id);
+      const note = await db.collection("application_notes").findOne({ _id: noteId });
+      if (!note) return res.status(404).json({ error: "Note not found" });
+      if (note.ownerId !== uid) {
+        return res.status(403).json({ error: "Only the note owner can delete this note" });
+      }
+
+      await db.collection("application_notes").deleteOne({ _id: note._id });
+      res.json({ status: "success" });
+    } catch (err) {
+      console.error("[ApplicationNotes] DELETE error:", err);
+      res.status(500).json({ error: "Internal Server Error" });
+    }
+  });
 
   // --- Real API Routes ---
   app.get("/api/v1/opportunities", validateRequest(z.object({ query: opportunityQuerySchema })), async (req, res) => {
@@ -2917,7 +3090,31 @@ ${JSON.stringify(userProfile, null, 2)}
   io.on("connection", (socket) => {
     logger.info(`[Socket] Client connected: ${socket.id}`);
     socket.emit("connected", { status: "ready" });
-    
+
+    // --- Application Note real-time co-editing ---
+    // Each open note is a room keyed by its id. A client that opens a note
+    // joins the room; when it edits, it emits "note:update" and we relay the
+    // latest title/blocks to every *other* client in the room. Persistence is
+    // handled by the editing client via POST /api/v1/application-notes
+    // (last write wins), mirroring the existing collaborative snippet editor.
+    socket.on("note:join", (data: { noteId?: string }) => {
+      if (data?.noteId) socket.join(`note_${data.noteId}`);
+    });
+
+    socket.on("note:leave", (data: { noteId?: string }) => {
+      if (data?.noteId) socket.leave(`note_${data.noteId}`);
+    });
+
+    socket.on("note:update", (payload: {
+      noteId?: string;
+      title?: string;
+      blocks?: any[];
+      userId?: string;
+    }) => {
+      if (!payload?.noteId) return;
+      socket.to(`note_${payload.noteId}`).emit("note:updated", payload);
+    });
+
     socket.on("disconnect", () => {
       logger.info(`[Socket] Client disconnected: ${socket.id}`);
     });

--- a/src/components/ApplicationNoteEditor.tsx
+++ b/src/components/ApplicationNoteEditor.tsx
@@ -1,0 +1,633 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  X,
+  Plus,
+  Type,
+  ListChecks,
+  Link2,
+  BellRing,
+  Trash2,
+  Check,
+  Loader2,
+  Users,
+} from "lucide-react";
+import { useSocket } from "../context/SocketContext";
+import {
+  fetchApplicationNote,
+  saveApplicationNote,
+  shareApplicationNote,
+} from "../services/apiClient";
+
+type ChecklistItem = { id: string; text: string; done: boolean };
+
+type Block = {
+  id: string;
+  type: "text" | "checklist" | "link" | "reminder";
+  text?: string;
+  url?: string;
+  items?: ChecklistItem[];
+  dueAt?: string;
+  done?: boolean;
+};
+
+type Note = {
+  id?: string;
+  _id?: string;
+  ownerId?: string;
+  applicationId: string;
+  title: string;
+  blocks: Block[];
+  sharedWith?: string[];
+};
+
+interface Props {
+  applicationId: string;
+  applicationTitle?: string;
+  currentUserId?: string;
+  onClose: () => void;
+}
+
+const uid = () =>
+  globalThis.crypto?.randomUUID?.() ??
+  `id_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+
+const freshBlock = (type: Block["type"]): Block => {
+  const block: Block = { id: uid(), type };
+  if (type === "text") block.text = "";
+  if (type === "link") {
+    block.url = "";
+    block.text = "";
+  }
+  if (type === "checklist") block.items = [{ id: uid(), text: "", done: false }];
+  if (type === "reminder") {
+    block.text = "";
+    block.dueAt = "";
+    block.done = false;
+  }
+  return block;
+};
+
+const emptyNote = (applicationId: string): Note => ({
+  applicationId,
+  title: "Application Workspace",
+  blocks: [freshBlock("text")],
+  sharedWith: [],
+});
+
+const normalize = (raw: any, applicationId: string): Note => ({
+  id: raw?.id || raw?._id,
+  _id: raw?._id,
+  ownerId: raw?.ownerId,
+  applicationId: raw?.applicationId || applicationId,
+  title: raw?.title || "Application Workspace",
+  blocks:
+    Array.isArray(raw?.blocks) && raw.blocks.length
+      ? raw.blocks
+      : [freshBlock("text")],
+  sharedWith: Array.isArray(raw?.sharedWith) ? raw.sharedWith : [],
+});
+
+export default function ApplicationNoteEditor({
+  applicationId,
+  applicationTitle,
+  currentUserId,
+  onClose,
+}: Props) {
+  const { socket } = useSocket();
+  const [note, setNote] = useState<Note | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [shareEmail, setShareEmail] = useState("");
+
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // ---- Load the existing note, or start a fresh (unsaved) one ----
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const existing = await fetchApplicationNote(applicationId);
+        if (cancelled) return;
+        setNote(existing ? normalize(existing, applicationId) : emptyNote(applicationId));
+      } catch (e: any) {
+        if (!cancelled) setError(e?.message || "Failed to load note");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [applicationId]);
+
+  const noteId = note?.id || note?._id;
+  const isOwner = !!note && (!note.ownerId || note.ownerId === currentUserId);
+
+  // ---- Real-time: join the note room, apply edits coming from other people ----
+  useEffect(() => {
+    if (!socket || !noteId) return;
+
+    socket.emit("note:join", { noteId });
+
+    const onRemoteUpdate = (payload: {
+      noteId: string;
+      title?: string;
+      blocks?: Block[];
+      userId?: string;
+    }) => {
+      if (payload.noteId !== noteId) return;
+      if (payload.userId && payload.userId === currentUserId) return;
+      setNote((prev) =>
+        prev
+          ? {
+              ...prev,
+              title: payload.title ?? prev.title,
+              blocks: payload.blocks ?? prev.blocks,
+            }
+          : prev
+      );
+    };
+
+    socket.on("note:updated", onRemoteUpdate);
+    return () => {
+      socket.emit("note:leave", { noteId });
+      socket.off("note:updated", onRemoteUpdate);
+    };
+  }, [socket, noteId, currentUserId]);
+
+  // ---- Debounced persistence ----
+  const scheduleSave = useCallback(
+    (next: Note) => {
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      saveTimer.current = setTimeout(async () => {
+        setSaving(true);
+        setError(null);
+        try {
+          const saved = await saveApplicationNote(applicationId, {
+            title: next.title,
+            blocks: next.blocks,
+          });
+          // Only pick up server-managed fields; keep local body as-is so we
+          // don't stomp on edits made while the request was in flight.
+          setNote((prev) =>
+            prev
+              ? {
+                  ...prev,
+                  id: saved?.id || saved?._id || prev.id,
+                  _id: saved?._id || prev._id,
+                  ownerId: saved?.ownerId ?? prev.ownerId,
+                  sharedWith: Array.isArray(saved?.sharedWith)
+                    ? saved.sharedWith
+                    : prev.sharedWith,
+                }
+              : prev
+          );
+        } catch (e: any) {
+          setError(e?.message || "Failed to save");
+        } finally {
+          setSaving(false);
+        }
+      }, 800);
+    },
+    [applicationId]
+  );
+
+  // ---- Single entry point for every local edit: update state, save, broadcast ----
+  const applyChange = useCallback(
+    (updater: (n: Note) => Note) => {
+      setNote((prev) => {
+        if (!prev) return prev;
+        const next = updater(prev);
+        scheduleSave(next);
+        const id = next.id || next._id;
+        if (socket && id) {
+          socket.emit("note:update", {
+            noteId: id,
+            title: next.title,
+            blocks: next.blocks,
+            userId: currentUserId,
+          });
+        }
+        return next;
+      });
+    },
+    [scheduleSave, socket, currentUserId]
+  );
+
+  const addBlock = (type: Block["type"]) =>
+    applyChange((n) => ({ ...n, blocks: [...n.blocks, freshBlock(type)] }));
+
+  const updateBlock = (id: string, patch: Partial<Block>) =>
+    applyChange((n) => ({
+      ...n,
+      blocks: n.blocks.map((b) => (b.id === id ? { ...b, ...patch } : b)),
+    }));
+
+  const removeBlock = (id: string) =>
+    applyChange((n) => ({ ...n, blocks: n.blocks.filter((b) => b.id !== id) }));
+
+  const addItem = (blockId: string) =>
+    applyChange((n) => ({
+      ...n,
+      blocks: n.blocks.map((b) =>
+        b.id === blockId
+          ? { ...b, items: [...(b.items || []), { id: uid(), text: "", done: false }] }
+          : b
+      ),
+    }));
+
+  const updateItem = (
+    blockId: string,
+    itemId: string,
+    patch: Partial<ChecklistItem>
+  ) =>
+    applyChange((n) => ({
+      ...n,
+      blocks: n.blocks.map((b) =>
+        b.id === blockId
+          ? {
+              ...b,
+              items: (b.items || []).map((it) =>
+                it.id === itemId ? { ...it, ...patch } : it
+              ),
+            }
+          : b
+      ),
+    }));
+
+  const removeItem = (blockId: string, itemId: string) =>
+    applyChange((n) => ({
+      ...n,
+      blocks: n.blocks.map((b) =>
+        b.id === blockId
+          ? { ...b, items: (b.items || []).filter((it) => it.id !== itemId) }
+          : b
+      ),
+    }));
+
+  // ---- Overall checklist progress across every checklist block ----
+  const progress = useMemo(() => {
+    const items = (note?.blocks || []).flatMap((b) =>
+      b.type === "checklist" ? b.items || [] : []
+    );
+    return { done: items.filter((it) => it.done).length, total: items.length };
+  }, [note]);
+
+  const handleShare = async () => {
+    if (!noteId || !shareEmail.trim()) return;
+    try {
+      const updated = await shareApplicationNote(noteId, {
+        addEmail: shareEmail.trim(),
+      });
+      setNote((prev) =>
+        prev ? { ...prev, sharedWith: updated?.sharedWith || prev.sharedWith } : prev
+      );
+      setShareEmail("");
+    } catch (e: any) {
+      setError(e?.message || "Failed to share");
+    }
+  };
+
+  const handleUnshare = async (userId: string) => {
+    if (!noteId) return;
+    try {
+      const updated = await shareApplicationNote(noteId, { removeUserId: userId });
+      setNote((prev) =>
+        prev ? { ...prev, sharedWith: updated?.sharedWith || [] } : prev
+      );
+    } catch (e: any) {
+      setError(e?.message || "Failed to update sharing");
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-border-theme bg-surface shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 border-b border-border-theme p-4">
+          <div className="min-w-0 flex-1">
+            <input
+              value={note?.title || ""}
+              onChange={(e) =>
+                applyChange((n) => ({ ...n, title: e.target.value }))
+              }
+              placeholder="Workspace title"
+              className="w-full bg-transparent text-lg font-semibold text-text-primary outline-none placeholder:text-text-muted"
+            />
+            {applicationTitle && (
+              <p className="truncate text-xs text-text-muted">
+                for {applicationTitle}
+              </p>
+            )}
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            {saving ? (
+              <span className="flex items-center gap-1 text-xs text-text-muted">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Saving
+              </span>
+            ) : (
+              <span className="text-xs text-text-muted">Saved</span>
+            )}
+            <button
+              onClick={onClose}
+              aria-label="Close workspace"
+              className="rounded-lg p-1.5 text-text-muted hover:bg-surface-secondary"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* Checklist progress */}
+        {progress.total > 0 && (
+          <div className="border-b border-border-theme px-4 py-2">
+            <div className="mb-1 flex justify-between text-xs text-text-muted">
+              <span>Checklist progress</span>
+              <span>
+                {progress.done}/{progress.total} done
+              </span>
+            </div>
+            <div className="h-2 w-full overflow-hidden rounded-full bg-surface-secondary">
+              <div
+                className="h-full rounded-full bg-emerald-500 transition-all"
+                style={{
+                  width: `${
+                    progress.total ? (progress.done / progress.total) * 100 : 0
+                  }%`,
+                }}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Body */}
+        <div className="flex-1 space-y-3 overflow-y-auto p-4">
+          {error && (
+            <div className="rounded-lg bg-red-500/10 px-3 py-2 text-sm text-red-400">
+              {error}
+            </div>
+          )}
+
+          {loading ? (
+            <div className="flex justify-center py-10">
+              <Loader2 className="h-5 w-5 animate-spin text-text-muted" />
+            </div>
+          ) : (
+            <>
+              {note?.blocks.map((block) => (
+                <BlockRow
+                  key={block.id}
+                  block={block}
+                  onChange={(patch) => updateBlock(block.id, patch)}
+                  onRemove={() => removeBlock(block.id)}
+                  onAddItem={() => addItem(block.id)}
+                  onUpdateItem={(itemId, patch) =>
+                    updateItem(block.id, itemId, patch)
+                  }
+                  onRemoveItem={(itemId) => removeItem(block.id, itemId)}
+                />
+              ))}
+
+              <div className="flex flex-wrap gap-2 pt-1">
+                <AddBtn
+                  icon={<Type className="h-3.5 w-3.5" />}
+                  label="Text"
+                  onClick={() => addBlock("text")}
+                />
+                <AddBtn
+                  icon={<ListChecks className="h-3.5 w-3.5" />}
+                  label="Checklist"
+                  onClick={() => addBlock("checklist")}
+                />
+                <AddBtn
+                  icon={<Link2 className="h-3.5 w-3.5" />}
+                  label="Link"
+                  onClick={() => addBlock("link")}
+                />
+                <AddBtn
+                  icon={<BellRing className="h-3.5 w-3.5" />}
+                  label="Reminder"
+                  onClick={() => addBlock("reminder")}
+                />
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Sharing (owner only) */}
+        {!loading && isOwner && (
+          <div className="border-t border-border-theme p-4">
+            <div className="mb-2 flex items-center gap-1.5 text-xs font-medium text-text-muted">
+              <Users className="h-3.5 w-3.5" /> Share with a teammate
+            </div>
+            <div className="flex gap-2">
+              <input
+                type="email"
+                value={shareEmail}
+                onChange={(e) => setShareEmail(e.target.value)}
+                disabled={!noteId}
+                placeholder={
+                  noteId
+                    ? "teammate@email.com"
+                    : "Type something first to enable sharing"
+                }
+                className="flex-1 rounded-lg border border-border-theme bg-surface-secondary px-3 py-1.5 text-sm text-text-primary outline-none disabled:opacity-50"
+              />
+              <button
+                onClick={handleShare}
+                disabled={!noteId || !shareEmail.trim()}
+                className="rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+              >
+                Invite
+              </button>
+            </div>
+            {!!note?.sharedWith?.length && (
+              <ul className="mt-2 space-y-1">
+                {note.sharedWith.map((u) => (
+                  <li
+                    key={u}
+                    className="flex items-center justify-between rounded-lg bg-surface-secondary px-3 py-1.5 text-xs text-text-secondary"
+                  >
+                    <span className="truncate">{u}</span>
+                    <button
+                      onClick={() => handleUnshare(u)}
+                      aria-label="Remove collaborator"
+                      className="text-text-muted hover:text-red-400"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AddBtn({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex items-center gap-1.5 rounded-lg border border-border-theme bg-surface-secondary px-2.5 py-1.5 text-xs font-medium text-text-secondary hover:text-text-primary"
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function BlockRow({
+  block,
+  onChange,
+  onRemove,
+  onAddItem,
+  onUpdateItem,
+  onRemoveItem,
+}: {
+  block: Block;
+  onChange: (patch: Partial<Block>) => void;
+  onRemove: () => void;
+  onAddItem: () => void;
+  onUpdateItem: (itemId: string, patch: Partial<ChecklistItem>) => void;
+  onRemoveItem: (itemId: string) => void;
+}) {
+  return (
+    <div className="group relative rounded-xl border border-border-theme bg-surface-secondary/40 p-3">
+      <button
+        onClick={onRemove}
+        aria-label="Remove block"
+        className="absolute right-2 top-2 rounded p-1 text-text-muted opacity-0 transition-opacity hover:text-red-400 group-hover:opacity-100"
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+      </button>
+
+      {block.type === "text" && (
+        <textarea
+          value={block.text || ""}
+          onChange={(e) => onChange({ text: e.target.value })}
+          rows={3}
+          placeholder="Write notes, essay drafts, ideas…"
+          className="w-full resize-y bg-transparent text-sm text-text-primary outline-none placeholder:text-text-muted"
+        />
+      )}
+
+      {block.type === "checklist" && (
+        <div className="space-y-1.5">
+          {(block.items || []).map((it) => (
+            <div key={it.id} className="flex items-center gap-2">
+              <button
+                onClick={() => onUpdateItem(it.id, { done: !it.done })}
+                aria-label={it.done ? "Mark task not done" : "Mark task done"}
+                className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border ${
+                  it.done
+                    ? "border-emerald-500 bg-emerald-500 text-white"
+                    : "border-border-theme"
+                }`}
+              >
+                {it.done && <Check className="h-3 w-3" />}
+              </button>
+              <input
+                value={it.text}
+                onChange={(e) => onUpdateItem(it.id, { text: e.target.value })}
+                placeholder="Task…"
+                className={`flex-1 bg-transparent text-sm outline-none ${
+                  it.done
+                    ? "text-text-muted line-through"
+                    : "text-text-primary"
+                }`}
+              />
+              <button
+                onClick={() => onRemoveItem(it.id)}
+                aria-label="Remove task"
+                className="text-text-muted hover:text-red-400"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          ))}
+          <button
+            onClick={onAddItem}
+            className="flex items-center gap-1 text-xs text-text-muted hover:text-text-primary"
+          >
+            <Plus className="h-3 w-3" /> Add task
+          </button>
+        </div>
+      )}
+
+      {block.type === "link" && (
+        <div className="space-y-1.5">
+          <input
+            value={block.text || ""}
+            onChange={(e) => onChange({ text: e.target.value })}
+            placeholder="Label (e.g. Portfolio)"
+            className="w-full bg-transparent text-sm font-medium text-text-primary outline-none placeholder:text-text-muted"
+          />
+          <input
+            value={block.url || ""}
+            onChange={(e) => onChange({ url: e.target.value })}
+            placeholder="https://…"
+            className="w-full bg-transparent text-sm text-emerald-400 outline-none placeholder:text-text-muted"
+          />
+          {block.url && (
+            <a
+              href={block.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block text-xs text-text-muted underline"
+            >
+              Open link
+            </a>
+          )}
+        </div>
+      )}
+
+      {block.type === "reminder" && (
+        <div className="flex flex-wrap items-center gap-2">
+          <BellRing className="h-4 w-4 shrink-0 text-amber-400" />
+          <input
+            value={block.text || ""}
+            onChange={(e) => onChange({ text: e.target.value })}
+            placeholder="Reminder…"
+            className="min-w-[8rem] flex-1 bg-transparent text-sm text-text-primary outline-none placeholder:text-text-muted"
+          />
+          <input
+            type="datetime-local"
+            value={block.dueAt || ""}
+            onChange={(e) => onChange({ dueAt: e.target.value })}
+            className="rounded-lg border border-border-theme bg-surface px-2 py-1 text-xs text-text-secondary outline-none"
+          />
+          <button
+            onClick={() => onChange({ done: !block.done })}
+            className={`rounded-lg px-2 py-1 text-xs ${
+              block.done
+                ? "bg-emerald-500/20 text-emerald-400"
+                : "bg-surface text-text-muted"
+            }`}
+          >
+            {block.done ? "Done" : "Mark done"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/planner/DegreePlannerHub.tsx
+++ b/src/components/planner/DegreePlannerHub.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { DragDropContext, DropResult } from '@hello-pangea/dnd';
 import { SemesterBoard } from './SemesterBoard';
 import { PrerequisiteAlert } from './PrerequisiteAlert';
-import { AcademicRoadmap, Course } from '../../../shared/schemas/academicRoadmap';
+import { AcademicRoadmap, Course } from '../../shared/schemas/academicRoadmap';
 
 const INITIAL_ROADMAP: AcademicRoadmap = {
   id: 'roadmap-1',
@@ -107,7 +107,16 @@ export const DegreePlannerHub: React.FC = () => {
       <DragDropContext onDragEnd={onDragEnd}>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           {roadmap.semesters.map((semester) => (
-            <SemesterBoard key={semester.id} semester={semester} />
+            <SemesterBoard
+              key={semester.id}
+              semester={{
+                id: semester.id,
+                term: semester.name,
+                year: semester.year,
+                courseIds: semester.courses.map((c) => c.id),
+              }}
+              courses={semester.courses}
+            />
           ))}
         </div>
       </DragDropContext>

--- a/src/controllers/academicRoadmapController.ts
+++ b/src/controllers/academicRoadmapController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { AcademicRoadmap, Course } from '../../shared/schemas/academicRoadmap';
+import { AcademicRoadmap, Course } from '../shared/schemas/academicRoadmap';
 
 interface PrerequisiteViolation {
   courseId: string;

--- a/src/models/applicationNoteSchema.ts
+++ b/src/models/applicationNoteSchema.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+/**
+ * A single row inside a "checklist" block.
+ */
+export const checklistItemSchema = z.object({
+  id: z.string().min(1),
+  text: z.string().max(1000).optional().default(""),
+  done: z.boolean().optional().default(false),
+});
+
+export type ChecklistItem = z.infer<typeof checklistItemSchema>;
+
+/**
+ * One content block in an application workspace note.
+ *
+ * `type` decides which of the optional fields carry meaning:
+ *   - "text"      -> `text`
+ *   - "checklist" -> `items`
+ *   - "link"      -> `url`, `text` (used as the label)
+ *   - "reminder"  -> `text`, `dueAt` (ISO / datetime-local string), `done`
+ *
+ * A single permissive shape (rather than a discriminated union) keeps the
+ * document easy to store in MongoDB and easy to evolve as new block types
+ * are added.
+ */
+export const noteBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.enum(["text", "checklist", "link", "reminder"]),
+  text: z.string().max(10000).optional().default(""),
+  url: z.string().max(2000).optional(),
+  items: z.array(checklistItemSchema).max(200).optional().default([]),
+  dueAt: z.string().max(40).optional(),
+  done: z.boolean().optional().default(false),
+});
+
+export type NoteBlock = z.infer<typeof noteBlockSchema>;
+
+/**
+ * Full ApplicationNote document as stored in the `application_notes` collection.
+ *
+ * Server-managed fields (`ownerId`, `sharedWith`, timestamps) are never trusted
+ * from the client — the API derives `ownerId` from the auth token and mutates
+ * `sharedWith` only through the dedicated share route.
+ */
+export const applicationNoteSchema = z.object({
+  ownerId: z.string().min(1),
+  applicationId: z.string().min(1),
+  title: z.string().max(200).optional().default("Application Workspace"),
+  blocks: z.array(noteBlockSchema).max(100).optional().default([]),
+  sharedWith: z.array(z.string().min(1)).max(50).optional().default([]),
+  createdAt: z.date().optional(),
+  updatedAt: z.date().optional(),
+});
+
+export type ApplicationNote = z.infer<typeof applicationNoteSchema>;
+
+/**
+ * The only fields a client may send when creating or updating a note body.
+ * `applicationId` links the note to a tracked application.
+ */
+export const applicationNoteInputSchema = z.object({
+  applicationId: z.string().min(1, "applicationId is required"),
+  title: z.string().max(200).optional(),
+  blocks: z.array(noteBlockSchema).max(100).optional(),
+});
+
+export type ApplicationNoteInput = z.infer<typeof applicationNoteInputSchema>;

--- a/src/pages/ApplicationTracker.tsx
+++ b/src/pages/ApplicationTracker.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Briefcase, Building2, Calendar, CheckCircle, Clock, ExternalLink, MessageSquare, AlertCircle, XCircle, Award, Bookmark, Trash2, Edit3, X, Save, Plus } from 'lucide-react';
+import { Briefcase, Building2, Calendar, CheckCircle, Clock, ExternalLink, MessageSquare, AlertCircle, XCircle, Award, Bookmark, Trash2, Edit3, X, Save, Plus, FileText } from 'lucide-react';
 import { auth } from '../lib/firebase';
 import { fetchApplications, updateApplicationTracker, deleteApplicationTracker } from '../services/apiClient';
+import ApplicationNoteEditor from '../components/ApplicationNoteEditor';
 
 interface Application {
   _id: string;
@@ -81,6 +82,7 @@ export const ApplicationTracker: React.FC = () => {
   const [activeModalApp, setActiveModalApp] = useState<Application | null>(null);
   const [modalNotes, setModalNotes] = useState('');
   const [savingNotes, setSavingNotes] = useState(false);
+  const [workspaceApp, setWorkspaceApp] = useState<Application | null>(null);
 
   useEffect(() => {
     loadApplications();
@@ -257,8 +259,15 @@ export const ApplicationTracker: React.FC = () => {
                                           {app.opportunity?.title || 'Untitled Opportunity'}
                                         </h3>
                                         <div className="flex items-center gap-1 shrink-0">
+                                          <button
+                                            onClick={(e) => { e.stopPropagation(); setWorkspaceApp(app); }}
+                                            className="p-1 text-text-secondary hover:text-emerald-400 transition-colors"
+                                            title="Open prep workspace"
+                                          >
+                                            <FileText className="w-3.5 h-3.5" />
+                                          </button>
                                           {app.opportunity?.applyUrl && (
-                                            <a 
+                                            <a
                                               href={app.opportunity.applyUrl}
                                               target="_blank"
                                               rel="noopener noreferrer"
@@ -403,6 +412,15 @@ export const ApplicationTracker: React.FC = () => {
         </AnimatePresence>
 
       </div>
+
+      {workspaceApp && (
+        <ApplicationNoteEditor
+          applicationId={workspaceApp._id || (workspaceApp as any).id}
+          applicationTitle={workspaceApp.opportunity?.title}
+          currentUserId={auth.currentUser?.uid}
+          onClose={() => setWorkspaceApp(null)}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## What & why

The Application Tracker only tracked **status + deadline**. This PR adds a **prep workspace** to each tracked application so students can draft essays, build document checklists, and coordinate with teammates without leaving YuvaHub.

## Changes

- **`ApplicationNote` schema** (`src/models/applicationNoteSchema.ts`) — Zod schema with `ownerId`, `applicationId`, `title`, `blocks[]` (block types: `text` / `checklist` / `link` / `reminder`), `sharedWith[]`, timestamps. Client payloads are restricted to `applicationNoteInputSchema`, so `ownerId` / `sharedWith` cannot be forged.
- **REST API** (`server.ts`) — auth-protected routes under `/api/v1/application-notes`:
  - `GET /:applicationId` — fetch the note (owner or shared users)
  - `POST /` — create on first save, or update the body (title + blocks)
  - `PATCH /:id/share` — **owner only**: add a collaborator by email or user id, or remove one
  - `DELETE /:id` — **owner only**
  - Access control via `canAccessNote()`: every read/write is gated on `ownerId === uid || sharedWith.includes(uid)`.
- **Realtime co-editing** (`server.ts`, Socket.IO) — `note:join` / `note:leave` / `note:update` events. Edits are relayed to other clients in a `note_<id>` room. Persistence stays with the editing client via `POST` (last-write-wins), mirroring the existing collaborative snippet editor.
- **API client** (`src/services/apiClient.ts`) — `fetchApplicationNote`, `saveApplicationNote`, `shareApplicationNote`, `deleteApplicationNote`.
- **Editor UI** (`src/components/ApplicationNoteEditor.tsx`) — modal workspace: block-based editing, an overall checklist progress bar, debounced autosave (800 ms), an owner-only "share with a teammate by email" panel, and live sync through `useSocket()`.
- **Entry point** (`src/pages/ApplicationTracker.tsx`) — a workspace button on every application card opens the editor.

### Unrelated fix (isolated in commit 1)

`main` currently fails `tsc --noEmit` (which blocks the pre-commit hook) because two **orphaned, unused** degree-planner files import `shared/schemas/academicRoadmap` from the repo root instead of `src/shared/`. Commit 1 corrects those paths and one prop mismatch. No behavior change — neither file is imported anywhere.

## Acceptance criteria

- [x] Users can create and edit a structured note document attached to any tracked application
- [x] Notes support interactive checklists with a visual progress indicator
- [x] Users can invite other registered users to view and edit their application notes
- [x] Multiple users can edit a shared note with real-time updates syncing across clients (Socket.IO; active when `VITE_WS_URL` / `VITE_API_URL` is configured)

## Testing

- `npm run lint` (`tsc --noEmit`) — passes, 0 errors
- `npm run build` — passes; client secret scan passes
- Manual: add/remove blocks, toggle checklist items (progress bar updates), autosave, share by email, second browser session receives live edits

## Notes / follow-ups

- Realtime uses last-write-wins (no OT/CRDT), consistent with the existing snippet editor. A follow-up could add CRDT (Yjs) for character-level merging.
- Sharing is by exact registered email; a user-search/autocomplete would improve UX later.

Closes #<1012>


