### PR TITLE
fix(build): resolve vendor chunk circular dependency causing forwardRef runtime error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -98,14 +98,11 @@ export default defineConfig(async ({ mode }) => {
               if (id.includes("recharts") || id.includes("d3-")) {
                 return "vendor-charts";
               }
-              if (id.includes("framer-motion") || id.includes("lucide-react")) {
-                return "vendor-ui";
-              }
               if (
-                id.includes("react-dom") ||
-                id.includes("react-router-dom") ||
-                id.includes("/react/") ||
-                id.includes("\\react\\")
+                id.includes("react") ||
+                id.includes("scheduler") ||
+                id.includes("framer-motion") ||
+                id.includes("lucide-react")
               ) {
                 return "vendor-react";
               }


### PR DESCRIPTION
## Summary

Resolves a production runtime issue where deployed builds encountered a blank screen and `Uncaught TypeError: Cannot read properties of undefined (reading 'forwardRef')` due to manual chunk splitting between React and UI libraries.

---

## Related Issue

Closes #1062 

---

## Changes Made

- Updated `manualChunks` in `vite.config.ts` to bundle React core, `scheduler`, `lucide-react`, and `framer-motion` together under `vendor-react`.
- Resolved ESM module evaluation ordering hazards where UI components depended on `React.forwardRef` before React finished initialization.

---

## Testing

- [x] Tested locally
- [x] Added/updated tests (if applicable)
- [ ] Screenshots attached (if applicable)

- Ran `npm run lint` (`tsc --noEmit`) with 0 errors.
- Ran client secret scanner with all assets passing.
- Ran full production build (`npm run build`) and verified bundle chunk generation.

---

## Screenshots

N/A

---

## Checklist

- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes before submitting.
- [x] I have updated the documentation (if required).
- [x] I have added or updated tests (if required).
- [x] No unnecessary files or debug code are included.
- [x] This pull request is ready for review.

---